### PR TITLE
get experiment nodes list when you don't specify nodes list parser option

### DIFF
--- a/iotlabsshcli/parser/open_a8.py
+++ b/iotlabsshcli/parser/open_a8.py
@@ -90,6 +90,9 @@ def open_a8_parse_and_run(opts):
     nodes = common.list_nodes(api, exp_id, opts.nodes_list,
                               opts.exclude_nodes_list)
 
+    # Only if nodes_list or exclude_nodes_list is not specify (nodes = [])
+    if not nodes: nodes = common._get_experiment_nodes_list(api, exp_id)
+
     # Only keep A8 nodes
     nodes = ["node-{0}".format(node)
              for node in nodes if node.startswith('a8')]

--- a/iotlabsshcli/parser/open_a8.py
+++ b/iotlabsshcli/parser/open_a8.py
@@ -27,6 +27,7 @@ from iotlabcli import auth
 from iotlabcli import helpers
 from iotlabcli import rest
 from iotlabcli.parser import common
+from iotlabcli.parser.common import _get_experiment_nodes_list
 import iotlabsshcli.open_a8
 
 
@@ -91,7 +92,8 @@ def open_a8_parse_and_run(opts):
                               opts.exclude_nodes_list)
 
     # Only if nodes_list or exclude_nodes_list is not specify (nodes = [])
-    if not nodes: nodes = common._get_experiment_nodes_list(api, exp_id)
+    if not nodes:
+        nodes = _get_experiment_nodes_list(api, exp_id)
 
     # Only keep A8 nodes
     nodes = ["node-{0}".format(node)


### PR DESCRIPTION
By default when you don't specify nodes_list or exclude_nodes_list parser option you get
an empty nodes list for the command.
Modify the behaviour of the parser for executing the command on all experiment nodes when you don't specify parser option. (-l grenoble,a8,4 or -e grenoble,a8,4)