### PR TITLE
Add 'run-script' subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The provided sub-commands are:
 | `flash-m3`   | Flash the given firmware on the M3 MCU of the A8 node. |
 | `reset-m3`   | Reset the M3 node. |
 | `wait-for-boot`  | Block the execution until all given nodes have booted or maximum wait time has expired |
+| `run-script`  | Run a given script in background on the given nodes |
 
 SSH CLI Tools can be used in conjunction with the
 [IoT-Lab CLI Tools](https://github.com/iot-lab/cli-tools) commands like
@@ -41,9 +42,13 @@ $ sudo pip install .
 ```
 ### Requirement:
 
-Open A8 nodes are reachable through a gateway SSH server (eg. IoT-LAB SSH frontend). For this reason you must
-verify that your SSH public key used by ssh-cli-tools has been recorded in your IoT-LAB user profile. You can
-find how to configure your IoT-LAB SSH access in this [tutorial](https://www.iot-lab.info/tutorials/configure-your-ssh-access/).
+### Requirements:
+
+Open A8 nodes are reachable through a gateway SSH server (eg. IoT-LAB SSH
+frontend). For this reason you must verify that your SSH public key used by
+ssh-cli-tools has been recorded in your IoT-LAB user profile. You can find how
+to configure your IoT-LAB SSH access in this
+[tutorial](https://www.iot-lab.info/tutorials/configure-your-ssh-access/).
 
 ### Examples:
 
@@ -89,6 +94,17 @@ $ open-a8-cli flash-m3 <firmware.elf> -l saclay,a8,2-3+5-7+9-10
             "node-a8-7.saclay.iot-lab.info",
             "node-a8-9.saclay.iot-lab.info",
             "node-a8-10.saclay.iot-lab.info"
+        ]
+    }
+}
+```
+* Run the script `/tmp/test.sh` on `node-a8-2` in saclay:
+```
+$ open-a8-cli run-script /tmp/test.sh -l saclay,a8,2
+{
+    "run-script": {
+        "0": [
+            "node-a8-2.saclay.iot-lab.info"
         ]
     }
 }

--- a/iotlabsshcli/open_a8.py
+++ b/iotlabsshcli/open_a8.py
@@ -55,6 +55,9 @@ def _nodes_grouped(nodes):
 _MKDIR_DST_CMD = 'mkdir -p {}'
 _UPDATE_M3_CMD = 'source /etc/profile && /usr/bin/flash_a8_m3 {}'
 _RESET_M3_CMD = 'source /etc/profile && /usr/bin/reset_a8_m3'
+_MAKE_EXECUTABLE_CMD = 'chmod +x {}'
+_RUN_SCRIPT_CMD = 'screen -S {screen} -dm bash -c \"{path}\"'
+_QUIT_SCRIPT_CMD = 'screen -X -S {screen} quit'
 
 
 def flash_m3(config_ssh, nodes, firmware, verbose=False):
@@ -112,3 +115,34 @@ def wait_for_boot(config_ssh, nodes, max_wait=120, verbose=False):
         result = {"1": nodes}
 
     return {"wait-for-boot": result}
+
+
+def run_script(config_ssh, nodes, script, verbose=False):
+    """Run a script in background on the A8 nodes."""
+
+    # Configure ssh.
+    groups = _nodes_grouped(nodes)
+    ssh = OpenA8Ssh(config_ssh, groups, verbose=verbose)
+
+    screen = '{user}-{exp_id}'.format(**config_ssh)
+    remote_script = os.path.join('~/A8/.iotlabsshcli',
+                                 os.path.basename(script))
+    script_data = {'screen': screen,
+                   'path': remote_script}
+
+    # Create destination directory
+    ssh.run(_MKDIR_DST_CMD.format(os.path.dirname(remote_script)))
+
+    # Copy script on sites.
+    ssh.scp(script, remote_script)
+
+    # Make script executable
+    ssh.run(_MAKE_EXECUTABLE_CMD.format(remote_script))
+
+    # Kill any running script
+    ssh.run(_QUIT_SCRIPT_CMD.format(**script_data))
+
+    # Run script on all nodes
+    result = ssh.run(_RUN_SCRIPT_CMD.format(**script_data))
+
+    return {"run-script": result}

--- a/iotlabsshcli/open_a8.py
+++ b/iotlabsshcli/open_a8.py
@@ -143,6 +143,6 @@ def run_script(config_ssh, nodes, script, verbose=False):
     ssh.run(_QUIT_SCRIPT_CMD.format(**script_data))
 
     # Run script on all nodes
-    result = ssh.run(_RUN_SCRIPT_CMD.format(**script_data))
+    result = ssh.run(_RUN_SCRIPT_CMD.format(**script_data), use_pty=False)
 
     return {"run-script": result}

--- a/iotlabsshcli/parser/open_a8_parser.py
+++ b/iotlabsshcli/parser/open_a8_parser.py
@@ -120,7 +120,7 @@ def open_a8_parse_and_run(opts):
                                                   verbose=opts.verbose)
     elif command == 'run-script':
         return iotlabsshcli.open_a8.run_script(config_ssh, nodes,
-                                               script=opts.script,
+                                               opts.script,
                                                verbose=opts.verbose)
     else:  # pragma: no cover
         raise ValueError('Unknown command {0}'.format(command))

--- a/iotlabsshcli/parser/open_a8_parser.py
+++ b/iotlabsshcli/parser/open_a8_parser.py
@@ -61,12 +61,19 @@ def parse_options():
     # wait-for-boot parser
     boot_parser = subparsers.add_parser('wait-for-boot',
                                         help='Waits until A8 node have boot')
-
     boot_parser.add_argument('--max-wait',
                              type=int,
                              default=120,
                              help='Maximum waiting delay for A8 nodes boot '
                                   '(in seconds)')
+
+    # run-script parser
+    run_script_parser = subparsers.add_parser('run-script',
+                                              help='Run a script in background'
+                                                   'on the A8 node')
+    run_script_parser.add_argument('script', help='script path.')
+    # nodes list or exclude list
+    common.add_nodes_selection_list(run_script_parser)
 
     # nodes list or exclude list
     common.add_nodes_selection_list(boot_parser)
@@ -86,6 +93,7 @@ def open_a8_parse_and_run(opts):
 
     config_ssh = {
         'user': user,
+        'exp_id': exp_id
     }
 
     nodes = common.list_nodes(api, exp_id, opts.nodes_list,
@@ -110,6 +118,10 @@ def open_a8_parse_and_run(opts):
         return iotlabsshcli.open_a8.wait_for_boot(config_ssh, nodes,
                                                   max_wait=opts.max_wait,
                                                   verbose=opts.verbose)
+    elif command == 'run-script':
+        return iotlabsshcli.open_a8.run_script(config_ssh, nodes,
+                                               script=opts.script,
+                                               verbose=opts.verbose)
     else:  # pragma: no cover
         raise ValueError('Unknown command {0}'.format(command))
 

--- a/iotlabsshcli/sshlib/open_a8_ssh.py
+++ b/iotlabsshcli/sshlib/open_a8_ssh.py
@@ -114,7 +114,7 @@ class OpenA8Ssh(object):
         if self.verbose:
             utils.enable_logger(utils.logger)
 
-    def run(self, command):
+    def run(self, command, **kwargs):
         """Run ssh command using Parallel SSH."""
         result = {"0": [], "1": []}
         for site in self.groups:
@@ -124,7 +124,7 @@ class OpenA8Ssh(object):
                                                   '.iot-lab.info'.format(site),
                                        proxy_user=self.config_ssh['user'])
             try:
-                output = client.run_command(command)
+                output = client.run_command(command, **kwargs)
                 client.join(output)
             except AuthenticationException:
                 raise OpenA8SshAuthenticationException(site)

--- a/iotlabsshcli/tests/open_a8_parser_test.py
+++ b/iotlabsshcli/tests/open_a8_parser_test.py
@@ -48,14 +48,8 @@ class TestMainNodeParser(MainMock):
         open_a8_parser.main(args)
         list_nodes.assert_called_with(self.api, 123, [self._nodes], None)
         flash_m3.assert_called_with({'user': 'username', 'exp_id': 123},
-                                     self._root_nodes,
-                                     'firmware.elf', verbose=False)
-
-        args = ['flash-m3', 'firmware.elf']
-        open_a8_parser.main(args)
-        list_nodes.assert_called_with(self.api, 123, None, None)
-        flash_m3.assert_called_with({'user': 'username', 'exp_id': 123}, self._root_nodes,
-                                    'firmware.elf', verbose=False)
+                                    self._root_nodes, 'firmware.elf',
+                                    verbose=False)
 
         exp_info_res = {"items": [{"network_address": node}
                                   for node in self._nodes]}
@@ -83,13 +77,6 @@ class TestMainNodeParser(MainMock):
                                     self._root_nodes,
                                     verbose=False)
 
-        args = ['reset-m3']
-        open_a8_parser.main(args)
-        list_nodes.assert_called_with(self.api, 123, None, None)
-        reset_m3.assert_called_with({'user': 'username', 'exp_id': 123},
-                                    self._root_nodes,
-                                    verbose=False)
-
         exp_info_res = {"items": [{"network_address": node}
                                   for node in self._nodes]}
         with patch.object(self.api, 'get_experiment_info',
@@ -98,8 +85,8 @@ class TestMainNodeParser(MainMock):
             args = ['reset-m3']
             open_a8_parser.main(args)
             list_nodes.assert_called_with(self.api, 123, None, None)
-            reset_m3.assert_called_with({'user': 'username', 'exp_id': 123}, self._root_nodes,
-                                        verbose=False)
+            reset_m3.assert_called_with({'user': 'username', 'exp_id': 123},
+                                        self._root_nodes, verbose=False)
 
     @patch('iotlabsshcli.open_a8.wait_for_boot')
     @patch('iotlabcli.parser.common.list_nodes')
@@ -132,7 +119,8 @@ class TestMainNodeParser(MainMock):
             args = ['wait-for-boot']
             open_a8_parser.main(args)
             list_nodes.assert_called_with(self.api, 123, None, None)
-            wait_for_boot.assert_called_with({'user': 'username', 'exp_id': 123},
+            wait_for_boot.assert_called_with({'user': 'username',
+                                              'exp_id': 123},
                                              self._root_nodes,
                                              max_wait=120,
                                              verbose=False)
@@ -151,12 +139,17 @@ class TestMainNodeParser(MainMock):
                                       self._root_nodes,
                                       'script.sh', verbose=False)
 
-        args = ['run-script', 'script.sh']
-        open_a8_parser.main(args)
-        list_nodes.assert_called_with(self.api, 123, None, None)
-        run_script.assert_called_with({'user': 'username', 'exp_id': 123},
-                                      self._root_nodes,
-                                      'script.sh', verbose=False)
+        exp_info_res = {"items": [{"network_address": node}
+                                  for node in self._nodes]}
+        with patch.object(self.api, 'get_experiment_info',
+                          Mock(return_value=exp_info_res)):
+            list_nodes.return_value = []
+            args = ['run-script', 'script.sh']
+            open_a8_parser.main(args)
+            list_nodes.assert_called_with(self.api, 123, None, None)
+            run_script.assert_called_with({'user': 'username', 'exp_id': 123},
+                                          self._root_nodes,
+                                          'script.sh', verbose=False)
 
     def test_main_unknown_function(self):
         """Run the parser.node.main with an unknown function."""

--- a/iotlabsshcli/tests/open_a8_parser_test.py
+++ b/iotlabsshcli/tests/open_a8_parser_test.py
@@ -47,7 +47,7 @@ class TestMainNodeParser(MainMock):
         args = ['flash-m3', 'firmware.elf', '-l', 'saclay,a8,1-5']
         open_a8_parser.main(args)
         list_nodes.assert_called_with(self.api, 123, [self._nodes], None)
-        flash_m3.assert_called_with({'user': 'username'}, self._root_nodes,
+        flash_m3.assert_called_with({'user': 'username', 'exp_id': 123}, self._root_nodes,
                                     'firmware.elf', verbose=False)
 
         args = ['flash-m3', 'firmware.elf']
@@ -64,7 +64,8 @@ class TestMainNodeParser(MainMock):
             args = ['flash-m3', 'firmware.elf']
             open_a8_parser.main(args)
             list_nodes.assert_called_with(self.api, 123, None, None)
-            flash_m3.assert_called_with({'user': 'username'}, self._root_nodes,
+            flash_m3.assert_called_with({'user': 'username', 'exp_id': 123},
+                                        self._root_nodes,
                                         'firmware.elf', verbose=False)
 
     @patch('iotlabsshcli.open_a8.reset_m3')
@@ -83,7 +84,8 @@ class TestMainNodeParser(MainMock):
         args = ['reset-m3']
         open_a8_parser.main(args)
         list_nodes.assert_called_with(self.api, 123, None, None)
-        reset_m3.assert_called_with({'user': 'username'}, self._root_nodes,
+        reset_m3.assert_called_with({'user': 'username', 'exp_id': 123},
+                                    self._root_nodes,
                                     verbose=False)
 
         exp_info_res = {"items": [{"network_address": node}
@@ -94,7 +96,7 @@ class TestMainNodeParser(MainMock):
             args = ['reset-m3']
             open_a8_parser.main(args)
             list_nodes.assert_called_with(self.api, 123, None, None)
-            reset_m3.assert_called_with({'user': 'username'}, self._root_nodes,
+            reset_m3.assert_called_with({'user': 'username', 'exp_id': 123}, self._root_nodes,
                                         verbose=False)
 
     @patch('iotlabsshcli.open_a8.wait_for_boot')
@@ -115,7 +117,7 @@ class TestMainNodeParser(MainMock):
         args = ['wait-for-boot', "--max-wait", '10', '-l', 'saclay,a8,1-5']
         open_a8_parser.main(args)
         list_nodes.assert_called_with(self.api, 123, [self._nodes], None)
-        wait_for_boot.assert_called_with({'user': 'username'},
+        wait_for_boot.assert_called_with({'user': 'username', 'exp_id': 123},
                                          self._root_nodes,
                                          max_wait=10,
                                          verbose=False)
@@ -132,6 +134,21 @@ class TestMainNodeParser(MainMock):
                                              self._root_nodes,
                                              max_wait=120,
                                              verbose=False)
+
+    @patch('iotlabsshcli.open_a8.run_script')
+    @patch('iotlabcli.parser.common.list_nodes')
+    def test_main_run_script(self, list_nodes, run_script):
+        """Run the parser.node.main with run-script subparser function."""
+        run_script.return_value = {'result': 'test'}
+        list_nodes.return_value = self._nodes
+
+        args = ['run-script', 'script.sh', '-l', 'saclay,a8,1-5']
+        open_a8_parser.main(args)
+        list_nodes.assert_called_with(self.api, 123, [self._nodes], None)
+        run_script.assert_called_with({'user': 'username', 'exp_id': 123},
+                                      self._root_nodes,
+                                      'script.sh', verbose=False)
+
 
     def test_main_unknown_function(self):
         """Run the parser.node.main with an unknown function."""

--- a/iotlabsshcli/tests/open_a8_parser_test.py
+++ b/iotlabsshcli/tests/open_a8_parser_test.py
@@ -109,7 +109,7 @@ class TestMainNodeParser(MainMock):
         args = ['wait-for-boot', '-l', 'saclay,a8,1-5']
         open_a8_parser.main(args)
         list_nodes.assert_called_with(self.api, 123, [self._nodes], None)
-        wait_for_boot.assert_called_with({'user': 'username'},
+        wait_for_boot.assert_called_with({'user': 'username', 'exp_id': 123},
                                          self._root_nodes,
                                          max_wait=120,
                                          verbose=False)

--- a/iotlabsshcli/tests/open_a8_parser_test.py
+++ b/iotlabsshcli/tests/open_a8_parser_test.py
@@ -47,13 +47,14 @@ class TestMainNodeParser(MainMock):
         args = ['flash-m3', 'firmware.elf', '-l', 'saclay,a8,1-5']
         open_a8_parser.main(args)
         list_nodes.assert_called_with(self.api, 123, [self._nodes], None)
-        flash_m3.assert_called_with({'user': 'username', 'exp_id': 123}, self._root_nodes,
-                                    'firmware.elf', verbose=False)
+        flash_m3.assert_called_with({'user': 'username', 'exp_id': 123},
+                                     self._root_nodes,
+                                     'firmware.elf', verbose=False)
 
         args = ['flash-m3', 'firmware.elf']
         open_a8_parser.main(args)
         list_nodes.assert_called_with(self.api, 123, None, None)
-        flash_m3.assert_called_with({'user': 'username'}, self._root_nodes,
+        flash_m3.assert_called_with({'user': 'username', 'exp_id': 123}, self._root_nodes,
                                     'firmware.elf', verbose=False)
 
         exp_info_res = {"items": [{"network_address": node}
@@ -78,7 +79,8 @@ class TestMainNodeParser(MainMock):
         args = ['reset-m3', '-l', 'saclay,a8,1-5']
         open_a8_parser.main(args)
         list_nodes.assert_called_with(self.api, 123, [self._nodes], None)
-        reset_m3.assert_called_with({'user': 'username'}, self._root_nodes,
+        reset_m3.assert_called_with({'user': 'username', 'exp_id': 123},
+                                    self._root_nodes,
                                     verbose=False)
 
         args = ['reset-m3']
@@ -130,7 +132,7 @@ class TestMainNodeParser(MainMock):
             args = ['wait-for-boot']
             open_a8_parser.main(args)
             list_nodes.assert_called_with(self.api, 123, None, None)
-            wait_for_boot.assert_called_with({'user': 'username'},
+            wait_for_boot.assert_called_with({'user': 'username', 'exp_id': 123},
                                              self._root_nodes,
                                              max_wait=120,
                                              verbose=False)
@@ -149,6 +151,12 @@ class TestMainNodeParser(MainMock):
                                       self._root_nodes,
                                       'script.sh', verbose=False)
 
+        args = ['run-script', 'script.sh']
+        open_a8_parser.main(args)
+        list_nodes.assert_called_with(self.api, 123, None, None)
+        run_script.assert_called_with({'user': 'username', 'exp_id': 123},
+                                      self._root_nodes,
+                                      'script.sh', verbose=False)
 
     def test_main_unknown_function(self):
         """Run the parser.node.main with an unknown function."""


### PR DESCRIPTION
This introduces an ~~(untested)~~ version of the `run-script` subcommand.
Big thanks @fsaintma for the `use_pty=False` trick :)

I tested with a script in `/tmp/test.sh` containing the following code:
```bash
#!/bin/bash

watch ls ~/A8
```

and ran:
```
$ open-a8-cli run-script /tmp/test.sh
```
and could connect afterward to the A8s of my experiment and found a screen session running. The session name is `<screen-nb>.<username>-<exp-id>`

It still needs some polishing though.