### PR TITLE
Add new commands: run-cmd, copy-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ $ git clone https://github.com/iot-lab/ssh-cli-tools.git
 $ cd ssh-cli-tools
 $ sudo pip install .
 ```
-### Requirement:
 
 ### Requirements:
 
@@ -54,7 +53,7 @@ to configure your IoT-LAB SSH access in this
 
 ### Examples:
 
-#### Start an experiment, wait for it ot be ready, wait for all A8 boot:
+#### Start an experiment, wait for it to be ready, wait for all A8 boot:
 ```
 $ experiment-cli submit -d 120 -l saclay,a8,1-10
 {
@@ -208,5 +207,5 @@ There is a screen on:
 	1877.<login>-<exp_id>	(Detached)
 1 Socket in /tmp/screens/S-root.
 ```
-<b>Note:</b> as run command you can pass --frontend option if you want to launch a script
+<b>Note:</b> similar to run command you can pass --frontend option if you want to launch a script
 in background on the SSH frontend.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ The provided sub-commands are:
 | Sub-command  | Function |
 | ------------ | -------- |
 | `flash-m3`   | Flash the given firmware on the M3 MCU of the A8 node. |
-| `reset-m3`   | Reset the M3 node. |
-| `wait-for-boot`  | Block the execution until all given nodes have booted or maximum wait time has expired |
-| `run-script`  | Run a given script in background on the given nodes |
+| `reset-m3`   | Reset the M3 node of the A8 node. |
+| `wait-for-boot`   | Block the execution until all given A8 nodes have booted or maximum wait time has expired |
+| `run-script`  | Run a given script in background (eg. screen session) on the given A8 nodes |
+| `run-cmd`   | Run a command on the given A8 nodes |
+| `copy-file`   | Copy a file on SSH frontend homedir directory (eg. ~/A8/.iotlabsshcli) |
 
 SSH CLI Tools can be used in conjunction with the
 [IoT-Lab CLI Tools](https://github.com/iot-lab/cli-tools) commands like
@@ -98,17 +100,6 @@ $ open-a8-cli flash-m3 <firmware.elf> -l saclay,a8,2-3+5-7+9-10
     }
 }
 ```
-* Run the script `/tmp/test.sh` on `node-a8-2` in saclay:
-```
-$ open-a8-cli run-script /tmp/test.sh -l saclay,a8,2
-{
-    "run-script": {
-        "0": [
-            "node-a8-2.saclay.iot-lab.info"
-        ]
-    }
-}
-```
 * Reset the M3 of one A8 node:
 ```
 $ open-a8-cli reset-m3 -l saclay,a8,2
@@ -123,20 +114,20 @@ $ open-a8-cli reset-m3 -l saclay,a8,2
 * Use the `--verbose` option to get the commands output:
 ```
 $ open-a8-cli --verbose reset-m3 -l saclay,a8,2
-Connecting via SSH proxy saclay.iot-lab.info:22 -> node-a8-2:22
-[node-a8-2]	Open On-Chip Debugger 0.9.0-dirty (2016-04-15-00:55)
-[node-a8-2]	Licensed under GNU GPL v2
-[node-a8-2]	For bug reports, read
-[node-a8-2]	http://openocd.org/doc/doxygen/bugs.html
-[node-a8-2]	adapter speed: 1000 kHz
+Connecting via SSH proxy saclay.iot-lab.info:22 -> node-a8-2.saclay.iot-lab.info:22
+[node-a8-2.saclay.iot-lab.info]	Open On-Chip Debugger 0.9.0-dirty (2016-04-15-00:55)
+[node-a8-2.saclay.iot-lab.info]	Licensed under GNU GPL v2
+[node-a8-2.saclay.iot-lab.info] For bug reports, read
+[node-a8-2.saclay.iot-lab.info]	http://openocd.org/doc/doxygen/bugs.html
+[node-a8-2.saclay.iot-lab.info]	adapter speed: 1000 kHz
 [...]
-[node-a8-2]	TargetName         Type       Endian TapName            State
-[node-a8-2]	--  ------------------ ---------- ------ ------------------ ------------
-[node-a8-2]	0* stm32f1x.cpu       cortex_m   little stm32f1x.cpu       running
-[node-a8-2]	Info : JTAG tap: stm32f1x.cpu tap/device found: 0x3ba00477 (mfg: 0x23b, part: 0xba00, ver: 0x3)
-[node-a8-2]	Info : JTAG tap: stm32f1x.bs tap/device found: 0x06414041 (mfg: 0x020, part: 0x6414, ver: 0x0)
-[node-a8-2]	shutdown command invoked
-[node-a8-2]	Return Value: 0
+[node-a8-2.saclay.iot-lab.info]	TargetName         Type       Endian TapName            State
+[node-a8-2.saclay.iot-lab.info]	--  ------------------ ---------- ------ ------------------ ------------
+[node-a8-2.saclay.iot-lab.info] 0* stm32f1x.cpu       cortex_m   little stm32f1x.cpu       running
+[node-a8-2.saclay.iot-lab.info]	Info : JTAG tap: stm32f1x.cpu tap/device found: 0x3ba00477 (mfg: 0x23b, part: 0xba00, ver: 0x3)
+[node-a8-2.saclay.iot-lab.info]	Info : JTAG tap: stm32f1x.bs tap/device found: 0x06414041 (mfg: 0x020, part: 0x6414, ver: 0x0)
+[node-a8-2.saclay.iot-lab.info]	shutdown command invoked
+[node-a8-2.saclay.iot-lab.info]	Return Value: 0
 {
     "reset-m3": {
         "0": [
@@ -145,3 +136,72 @@ Connecting via SSH proxy saclay.iot-lab.info:22 -> node-a8-2:22
     }
 }
 ```
+* Run a command on A8 nodes
+```
+$ open-a8-cli --verbose run-cmd "uname -a" -l saclay,a8,2-3
+Connecting via SSH proxy saclay.iot-lab.info:22 -> node-a8-2.saclay.iot-lab.info:22
+[node-a8-2.saclay.iot-lab.info]	Linux node-a8-2 3.18.5-iotlab+ #9 Thu Sep 1 16:17:22 CEST 2016 armv7l GNU/Linux
+[node-a8-3.saclay.iot-lab.info]	Linux node-a8-3 3.18.5-iotlab+ #9 Thu Sep 1 16:17:22 CEST 2016 armv7l GNU/Linux
+{
+    "run-cmd": {
+        "0": [
+            "node-a8-2.saclay.iot-lab.info",
+            "node-a8-3.saclay.iot-lab.info"
+        ]
+    }
+}
+```
+* Run a command on SSH frontend 
+```
+$ open-a8-cli --verbose run-cmd "uname -a" --frontend
+[saclay.iot-lab.info]	Linux saclay 3.16.0-4-amd64 #1 SMP Debian 3.16.36-1+deb8u1 (2016-09-03) x86_64 GNU/Linux
+{
+    "run-cmd": {
+        "0": [
+            "saclay.iot-lab.info"
+        ]
+    }
+}
+```
+* Copy file on SSH frontend homedir directory (eg. ~/A8/.iotlabsshcli). This directory
+is mounting by A8 nodes during experiment.
+```
+$ open-a8-cli copy-file test.tar.gz 
+{
+    "run-cmd": {
+        "0": [
+            "saclay.iot-lab.info"
+        ]
+    }
+}
+$ open-a8-cli run-cmd "tar -xzvf ~/A8/.iotlabsshcli/test.tar.gz -C ~/A8/.iotlabsshcli/" --frontend
+{
+    "run-cmd": {
+        "0": [
+            "saclay.iot-lab.info"
+        ]
+    }
+}
+```
+* Run the script `/tmp/test.sh` on `node-a8-2` in saclay:
+```
+$ open-a8-cli run-script /tmp/test.sh -l saclay,a8,2
+{
+    "run-script": {
+        "0": [
+            "node-a8-2.saclay.iot-lab.info"
+        ]
+    }
+}
+```
+Note: a screen session is launched on the A8 node which
+startup script
+
+```
+root@node-a8-2:~# screen -ls
+There is a screen on:
+	1877.<login>-<exp_id>	(Detached)
+1 Socket in /tmp/screens/S-root.
+```
+Note: as run command you can pass --frontend option if you want to launch a script
+in background on the SSH frontend.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ The provided sub-commands are:
 | `flash-m3`   | Flash the given firmware on the M3 MCU of A8 nodes |
 | `reset-m3`   | Reset the M3 node of A8 nodes |
 | `wait-for-boot`   | Block the execution until all given A8 nodes have booted or maximum wait time has expired |
-| `run-script`  | Run a given script in background (eg. screen session) on the given A8 nodes |
+| `run-script`  | Run a given script in background (screen session) on the given A8 nodes |
 | `run-cmd`   | Run a command on the given A8 nodes |
-| `copy-file`   | Copy a file on SSH frontend homedir directory (eg. ~/A8/.iotlabsshcli) |
+| `copy-file`   | Copy a file on SSH frontend homedir directory (~/A8/.iotlabsshcli) |
 
 SSH CLI Tools can be used in conjunction with the
 [IoT-Lab CLI Tools](https://github.com/iot-lab/cli-tools) commands like
@@ -46,7 +46,7 @@ $ sudo pip install .
 
 ### Requirements:
 
-Open A8 nodes are reachable through a gateway SSH server (eg. IoT-LAB SSH
+Open A8 nodes are reachable through a gateway SSH server (IoT-LAB SSH
 frontend). For this reason you must verify that your SSH public key used by
 ssh-cli-tools has been recorded in your IoT-LAB user profile. You can find how
 to configure your IoT-LAB SSH access in this
@@ -166,7 +166,7 @@ $ open-a8-cli --verbose run-cmd "uname -a" --frontend
     }
 }
 ```
-#### Copy file on SSH frontend homedir directory (eg. ~/A8/.iotlabsshcli):
+#### Copy file on SSH frontend homedir directory (~/A8/.iotlabsshcli):
 ```
 $ open-a8-cli copy-file test.tar.gz 
 {
@@ -185,7 +185,7 @@ $ open-a8-cli run-cmd "tar -xzvf ~/A8/.iotlabsshcli/test.tar.gz -C ~/A8/.iotlabs
     }
 }
 ```
-<b>Note:</b> A8 homedir directory is mounting (eg. NFS) by A8 nodes during experiment.
+<b>Note:</b> A8 homedir directory is mounted (via NFS) by A8 nodes during experiment.
 
 #### Run the script `/tmp/test.sh` on `node-a8-2` in saclay:
 ```

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The provided sub-commands are:
 
 | Sub-command  | Function |
 | ------------ | -------- |
-| `flash-m3`   | Flash the given firmware on the M3 MCU of the A8 node. |
-| `reset-m3`   | Reset the M3 node of the A8 node. |
+| `flash-m3`   | Flash the given firmware on the M3 MCU of A8 nodes |
+| `reset-m3`   | Reset the M3 node of A8 nodes |
 | `wait-for-boot`   | Block the execution until all given A8 nodes have booted or maximum wait time has expired |
 | `run-script`  | Run a given script in background (eg. screen session) on the given A8 nodes |
 | `run-cmd`   | Run a command on the given A8 nodes |
@@ -54,7 +54,7 @@ to configure your IoT-LAB SSH access in this
 
 ### Examples:
 
-* Start an experiment, wait for it ot be ready, wait for all A8 boot
+#### Start an experiment, wait for it ot be ready, wait for all A8 boot:
 ```
 $ experiment-cli submit -d 120 -l saclay,a8,1-10
 {
@@ -82,8 +82,9 @@ $ open-a8-cli wait-for-boot
     }
 }
 ```
-Note: node-a8-4 and node-a8-8 are broken in Saclay.
-* Flash a firmware on the M3 of the working nodes:
+<b>Note:</b> node-a8-4 and node-a8-8 are broken in Saclay.
+
+#### Flash a firmware on the M3 of the working node:
 ```
 $ open-a8-cli flash-m3 <firmware.elf> -l saclay,a8,2-3+5-7+9-10
 {
@@ -100,7 +101,8 @@ $ open-a8-cli flash-m3 <firmware.elf> -l saclay,a8,2-3+5-7+9-10
     }
 }
 ```
-* Reset the M3 of one A8 node:
+
+#### Reset the M3 of one A8 node:
 ```
 $ open-a8-cli reset-m3 -l saclay,a8,2
 {
@@ -111,7 +113,8 @@ $ open-a8-cli reset-m3 -l saclay,a8,2
     }
 }
 ```
-* Use the `--verbose` option to get the commands output:
+
+#### Use the `--verbose` option to get the commands output:
 ```
 $ open-a8-cli --verbose reset-m3 -l saclay,a8,2
 Connecting via SSH proxy saclay.iot-lab.info:22 -> node-a8-2.saclay.iot-lab.info:22
@@ -136,7 +139,7 @@ Connecting via SSH proxy saclay.iot-lab.info:22 -> node-a8-2.saclay.iot-lab.info
     }
 }
 ```
-* Run a command on A8 nodes
+#### Run a command on two A8 nodes:
 ```
 $ open-a8-cli --verbose run-cmd "uname -a" -l saclay,a8,2-3
 Connecting via SSH proxy saclay.iot-lab.info:22 -> node-a8-2.saclay.iot-lab.info:22
@@ -151,7 +154,7 @@ Connecting via SSH proxy saclay.iot-lab.info:22 -> node-a8-2.saclay.iot-lab.info
     }
 }
 ```
-* Run a command on SSH frontend 
+#### Run a command on SSH frontend: 
 ```
 $ open-a8-cli --verbose run-cmd "uname -a" --frontend
 [saclay.iot-lab.info]	Linux saclay 3.16.0-4-amd64 #1 SMP Debian 3.16.36-1+deb8u1 (2016-09-03) x86_64 GNU/Linux
@@ -163,8 +166,7 @@ $ open-a8-cli --verbose run-cmd "uname -a" --frontend
     }
 }
 ```
-* Copy file on SSH frontend homedir directory (eg. ~/A8/.iotlabsshcli). This directory
-is mounting by A8 nodes during experiment.
+#### Copy file on SSH frontend homedir directory (eg. ~/A8/.iotlabsshcli):
 ```
 $ open-a8-cli copy-file test.tar.gz 
 {
@@ -183,7 +185,9 @@ $ open-a8-cli run-cmd "tar -xzvf ~/A8/.iotlabsshcli/test.tar.gz -C ~/A8/.iotlabs
     }
 }
 ```
-* Run the script `/tmp/test.sh` on `node-a8-2` in saclay:
+<b>Note:</b> A8 homedir directory is mounting (eg. NFS) by A8 nodes during experiment.
+
+#### Run the script `/tmp/test.sh` on `node-a8-2` in saclay:
 ```
 $ open-a8-cli run-script /tmp/test.sh -l saclay,a8,2
 {
@@ -194,8 +198,7 @@ $ open-a8-cli run-script /tmp/test.sh -l saclay,a8,2
     }
 }
 ```
-Note: a screen session is launched on the A8 node which
-startup script
+<b>Note:</b> a screen session is launched on the A8 node which startup script
 
 ```
 root@node-a8-2:~# screen -ls
@@ -203,5 +206,5 @@ There is a screen on:
 	1877.<login>-<exp_id>	(Detached)
 1 Socket in /tmp/screens/S-root.
 ```
-Note: as run command you can pass --frontend option if you want to launch a script
+<b>Note:</b> as run command you can pass --frontend option if you want to launch a script
 in background on the SSH frontend.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ $ open-a8-cli run-script /tmp/test.sh -l saclay,a8,2
     }
 }
 ```
-<b>Note:</b> a screen session is launched on the A8 node which startup script
+<b>Note:</b> a screen session is launched on the A8 node
+to actually run the script and provide easy access to outputs if needed.
+When the script ends, the screen session is terminated and the logs are gone.
 
 ```
 root@node-a8-2:~# screen -ls

--- a/iotlabsshcli/open_a8.py
+++ b/iotlabsshcli/open_a8.py
@@ -120,18 +120,13 @@ def wait_for_boot(config_ssh, nodes, max_wait=120, verbose=False):
 
 
 def run_cmd(config_ssh, nodes, cmd, run_on_frontend=False, verbose=False):
-    """ Run a command on the A8 nodes or on the
-    SSH frontend
-    """
+    """ Run a command on the A8 nodes or on the SSH frontend. """
 
     # Configure ssh.
     groups = _nodes_grouped(nodes)
     ssh = OpenA8Ssh(config_ssh, groups, verbose=verbose)
     try:
-        if run_on_frontend:
-            result = ssh.run(cmd, with_proxy=False)
-        else:
-            result = ssh.run(cmd)
+        result = ssh.run(cmd, with_proxy=not run_on_frontend)
     except OpenA8SshAuthenticationException as exc:
         print(exc.msg)
         result = {"1": nodes}
@@ -195,15 +190,12 @@ def run_script(config_ssh, nodes, script, run_on_frontend=False,
         ssh.run(_MAKE_EXECUTABLE_CMD.format(remote_script),
                 with_proxy=with_proxy)
 
-        if not run_on_frontend:
-            with_proxy = True
-
         # Kill any running script
         ssh.run(_QUIT_SCRIPT_CMD.format(**script_data),
-                with_proxy=with_proxy)
+                with_proxy=not run_on_frontend)
 
         # Run script
         result = ssh.run(_RUN_SCRIPT_CMD.format(**script_data),
-                         with_proxy=with_proxy, use_pty=False)
+                         with_proxy=not run_on_frontend, use_pty=False)
 
     return {"run-script": result}

--- a/iotlabsshcli/open_a8.py
+++ b/iotlabsshcli/open_a8.py
@@ -119,7 +119,7 @@ def wait_for_boot(config_ssh, nodes, max_wait=120, verbose=False):
     return {"wait-for-boot": result}
 
 
-def run_cmd(config_ssh, nodes, cmd, frontend=False, verbose=False):
+def run_cmd(config_ssh, nodes, cmd, run_on_frontend=False, verbose=False):
     """ Run a command on the A8 nodes or on the
     SSH frontend
     """
@@ -128,7 +128,7 @@ def run_cmd(config_ssh, nodes, cmd, frontend=False, verbose=False):
     groups = _nodes_grouped(nodes)
     ssh = OpenA8Ssh(config_ssh, groups, verbose=verbose)
     try:
-        if frontend:
+        if run_on_frontend:
             result = ssh.run(cmd, with_proxy=False)
         else:
             result = ssh.run(cmd)
@@ -163,7 +163,7 @@ def copy_file(config_ssh, nodes, file_path, verbose=False):
     return {"copy-file": result}
 
 
-def run_script(config_ssh, nodes, script, frontend=False,
+def run_script(config_ssh, nodes, script, run_on_frontend=False,
                verbose=False):
     """Run a script in background on the A8 nodes
     or on the SSH frontend
@@ -195,7 +195,7 @@ def run_script(config_ssh, nodes, script, frontend=False,
         ssh.run(_MAKE_EXECUTABLE_CMD.format(remote_script),
                 with_proxy=with_proxy)
 
-        if not frontend:
+        if not run_on_frontend:
             with_proxy = True
 
         # Kill any running script

--- a/iotlabsshcli/open_a8.py
+++ b/iotlabsshcli/open_a8.py
@@ -140,7 +140,7 @@ def run_cmd(config_ssh, nodes, cmd, frontend=False, verbose=False):
 
 
 def copy_file(config_ssh, nodes, file_path, verbose=False):
-    """ Copy a file on the A8 SSH frontend directory
+    """ Copy a file on the A8 SSH frontend(s) directory(es)
     (~/A8/.iotlabsshcli/)
     """
 

--- a/iotlabsshcli/open_a8.py
+++ b/iotlabsshcli/open_a8.py
@@ -119,7 +119,7 @@ def wait_for_boot(config_ssh, nodes, max_wait=120, verbose=False):
     return {"wait-for-boot": result}
 
 
-def run_cmd(config_ssh, nodes, cmd, frontend, verbose=False):
+def run_cmd(config_ssh, nodes, cmd, frontend=False, verbose=False):
     """ Run a command on the A8 nodes or on the
     SSH frontend
     """
@@ -163,7 +163,7 @@ def copy_file(config_ssh, nodes, file_path, verbose=False):
     return {"copy-file": result}
 
 
-def run_script(config_ssh, nodes, script, frontend,
+def run_script(config_ssh, nodes, script, frontend=False,
                verbose=False):
     """Run a script in background on the A8 nodes
     or on the SSH frontend

--- a/iotlabsshcli/open_a8.py
+++ b/iotlabsshcli/open_a8.py
@@ -117,6 +117,21 @@ def wait_for_boot(config_ssh, nodes, max_wait=120, verbose=False):
     return {"wait-for-boot": result}
 
 
+def run_cmd(config_ssh, nodes, cmd, verbose=False):
+    """ Run a command on the A8 nodes."""
+
+    # Configure ssh.
+    groups = _nodes_grouped(nodes)
+    ssh = OpenA8Ssh(config_ssh, groups, verbose=verbose)
+    try:
+        result = ssh.run(cmd)
+    except OpenA8SshAuthenticationException as exc:
+        print(exc.msg)
+        result = {"1": nodes}
+
+    return {"run-cmd": result}
+
+
 def run_script(config_ssh, nodes, script, verbose=False):
     """Run a script in background on the A8 nodes."""
 

--- a/iotlabsshcli/open_a8.py
+++ b/iotlabsshcli/open_a8.py
@@ -132,8 +132,35 @@ def run_cmd(config_ssh, nodes, cmd, verbose=False):
     return {"run-cmd": result}
 
 
-def run_script(config_ssh, nodes, script, verbose=False):
-    """Run a script in background on the A8 nodes."""
+def copy_file(config_ssh, nodes, file_path, verbose=False):
+    """ Copy a file on the A8 SSH frontend directory
+    (~/A8/.iotlabsshcli/)
+    """
+
+    # Configure ssh.
+    groups = _nodes_grouped(nodes)
+    ssh = OpenA8Ssh(config_ssh, groups, verbose=verbose)
+    remote_file = os.path.join('~/A8/.iotlabsshcli',
+                               os.path.basename(file_path))
+    try:
+        # Create file destination directory
+        ssh.run(_MKDIR_DST_CMD.format(os.path.dirname(remote_file)),
+                with_proxy=False)
+    except OpenA8SshAuthenticationException as exc:
+        print(exc.msg)
+        result = {"1": nodes}
+    else:
+        # Copy file on sites.
+        result = ssh.scp(file_path, remote_file)
+
+    return {"copy-file": result}
+
+
+def run_script(config_ssh, nodes, script, frontend,
+               verbose=False):
+    """Run a script in background on the A8 nodes
+    or on the SSH frontend
+    """
 
     # Configure ssh.
     groups = _nodes_grouped(nodes)

--- a/iotlabsshcli/parser/open_a8_parser.py
+++ b/iotlabsshcli/parser/open_a8_parser.py
@@ -85,6 +85,15 @@ def parse_options():
     # nodes list or exclude list
     common.add_nodes_selection_list(run_cmd_parser)
 
+    # copy-file parser
+    copy_file_parser = subparsers.add_parser('copy-file',
+                                             help='Copy file on'
+                                                  ' SSH frontend directory'
+                                                  ' (~/A8/.iotlabsshcli/)')
+    copy_file_parser.add_argument('file_path', help='File path')
+    # nodes list or exclude list
+    common.add_nodes_selection_list(copy_file_parser)
+
     parser.add_argument('--verbose',
                         action='store_true',
                         help='Set verbose output')
@@ -133,6 +142,10 @@ def open_a8_parse_and_run(opts):
         return iotlabsshcli.open_a8.run_cmd(config_ssh, nodes,
                                             opts.cmd,
                                             verbose=opts.verbose)
+    elif command == 'copy-file':
+        return iotlabsshcli.open_a8.copy_file(config_ssh, nodes,
+                                              opts.file_path,
+                                              verbose=opts.verbose)
     else:  # pragma: no cover
         raise ValueError('Unknown command {0}'.format(command))
 

--- a/iotlabsshcli/parser/open_a8_parser.py
+++ b/iotlabsshcli/parser/open_a8_parser.py
@@ -54,7 +54,7 @@ def parse_options():
 
     # reset-m3 parser
     reset_parser = subparsers.add_parser('reset-m3',
-                                         help='reset the M3 of A8 node')
+                                         help='Reset the M3 of A8 node')
     # nodes list or exclude list
     common.add_nodes_selection_list(reset_parser)
 
@@ -66,11 +66,13 @@ def parse_options():
                              default=120,
                              help='Maximum waiting delay for A8 nodes boot '
                                   '(in seconds)')
+    # nodes list or exclude list
+    common.add_nodes_selection_list(boot_parser)
 
     # run-script parser
     run_script_parser = subparsers.add_parser('run-script',
                                               help='Run a script in background'
-                                                   'on the A8 node')
+                                                   ' on the A8 node')
     run_script_parser.add_argument('script', help='script path.')
     # nodes list or exclude list
     common.add_nodes_selection_list(run_script_parser)

--- a/iotlabsshcli/parser/open_a8_parser.py
+++ b/iotlabsshcli/parser/open_a8_parser.py
@@ -47,20 +47,20 @@ def parse_options():
     # update-m3 parser
     update_parser = subparsers.add_parser('flash-m3',
                                           help='Flash the M3 firmware of A8 '
-                                               'node')
+                                               'nodes')
     update_parser.add_argument('firmware', help='firmware elf path.')
     # nodes list or exclude list
     common.add_nodes_selection_list(update_parser)
 
     # reset-m3 parser
     reset_parser = subparsers.add_parser('reset-m3',
-                                         help='Reset the M3 of A8 node')
+                                         help='Reset the M3 of A8 nodes')
     # nodes list or exclude list
     common.add_nodes_selection_list(reset_parser)
 
     # wait-for-boot parser
     boot_parser = subparsers.add_parser('wait-for-boot',
-                                        help='Waits until A8 node have boot')
+                                        help='Waits until A8 nodes have boot')
     boot_parser.add_argument('--max-wait',
                              type=int,
                              default=120,
@@ -72,7 +72,7 @@ def parse_options():
     # run-script parser
     run_script_parser = subparsers.add_parser('run-script',
                                               help='Run a script in background'
-                                                   ' on the A8 node')
+                                                   ' on A8 nodes')
     run_script_parser.add_argument('script', help='script path.')
     # nodes list or exclude list
     common.add_nodes_selection_list(run_script_parser)

--- a/iotlabsshcli/parser/open_a8_parser.py
+++ b/iotlabsshcli/parser/open_a8_parser.py
@@ -74,14 +74,17 @@ def parse_options():
                                               help='Run a script in background'
                                                    ' on A8 nodes')
     run_script_parser.add_argument('script', help='script path.')
+    run_script_parser.add_argument('--frontend', action='store_true',
+                                   help='Execution on SSH frontend')
     # nodes list or exclude list
     common.add_nodes_selection_list(run_script_parser)
 
     # run-cmd parser
     run_cmd_parser = subparsers.add_parser('run-cmd',
-                                           help='Run a command'
-                                                ' on the A8 node')
-    run_cmd_parser.add_argument('cmd', help='Command.')
+                                           help='Run a command on A8 nodes')
+    run_cmd_parser.add_argument('cmd', help='Command')
+    run_cmd_parser.add_argument('--frontend', action='store_true',
+                                help='Execution on SSH frontend')
     # nodes list or exclude list
     common.add_nodes_selection_list(run_cmd_parser)
 
@@ -137,10 +140,12 @@ def open_a8_parse_and_run(opts):
     elif command == 'run-script':
         return iotlabsshcli.open_a8.run_script(config_ssh, nodes,
                                                opts.script,
+                                               opts.frontend,
                                                verbose=opts.verbose)
     elif command == 'run-cmd':
         return iotlabsshcli.open_a8.run_cmd(config_ssh, nodes,
                                             opts.cmd,
+                                            opts.frontend,
                                             verbose=opts.verbose)
     elif command == 'copy-file':
         return iotlabsshcli.open_a8.copy_file(config_ssh, nodes,

--- a/iotlabsshcli/parser/open_a8_parser.py
+++ b/iotlabsshcli/parser/open_a8_parser.py
@@ -77,8 +77,13 @@ def parse_options():
     # nodes list or exclude list
     common.add_nodes_selection_list(run_script_parser)
 
+    # run-cmd parser
+    run_cmd_parser = subparsers.add_parser('run-cmd',
+                                           help='Run a command'
+                                                ' on the A8 node')
+    run_cmd_parser.add_argument('cmd', help='Command.')
     # nodes list or exclude list
-    common.add_nodes_selection_list(boot_parser)
+    common.add_nodes_selection_list(run_cmd_parser)
 
     parser.add_argument('--verbose',
                         action='store_true',
@@ -124,6 +129,10 @@ def open_a8_parse_and_run(opts):
         return iotlabsshcli.open_a8.run_script(config_ssh, nodes,
                                                opts.script,
                                                verbose=opts.verbose)
+    elif command == 'run-cmd':
+        return iotlabsshcli.open_a8.run_cmd(config_ssh, nodes,
+                                            opts.cmd,
+                                            verbose=opts.verbose)
     else:  # pragma: no cover
         raise ValueError('Unknown command {0}'.format(command))
 

--- a/iotlabsshcli/sshlib/open_a8_ssh.py
+++ b/iotlabsshcli/sshlib/open_a8_ssh.py
@@ -21,6 +21,7 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 
+from __future__ import print_function
 import sys
 import time
 from pssh import ParallelSSHClient, SSHClient, utils
@@ -186,13 +187,11 @@ class OpenA8Ssh(object):
             raise OpenA8SshAuthenticationException(site)
         except ConnectionErrorException:
             if self.verbose:
-                print("Node {} not ready."
-                      .format(node))
+                print("Node {} not ready.".format(node))
         else:
             client.client.close()
             if self.verbose:
-                print("Node {} ready."
-                      .format(node))
+                print("Node {} ready.".format(node))
             result = True
         finally:
             dev_null.close()

--- a/iotlabsshcli/sshlib/open_a8_ssh.py
+++ b/iotlabsshcli/sshlib/open_a8_ssh.py
@@ -186,13 +186,11 @@ class OpenA8Ssh(object):
             raise OpenA8SshAuthenticationException(site)
         except ConnectionErrorException:
             if self.verbose:
-                print("Node {} not ready."
-                      .format(node))
+                print("Node {} not ready.".format(node))
         else:
             client.client.close()
             if self.verbose:
-                print("Node {} ready."
-                      .format(node))
+                print("Node {} ready.".format(node))
             result = True
         finally:
             dev_null.close()

--- a/iotlabsshcli/sshlib/open_a8_ssh.py
+++ b/iotlabsshcli/sshlib/open_a8_ssh.py
@@ -186,11 +186,13 @@ class OpenA8Ssh(object):
             raise OpenA8SshAuthenticationException(site)
         except ConnectionErrorException:
             if self.verbose:
-                print("Node {} not ready.".format(node))
+                print("Node {} not ready."
+                      .format(node))
         else:
             client.client.close()
             if self.verbose:
-                print("Node {} ready.".format(node))
+                print("Node {} ready."
+                      .format(node))
             result = True
         finally:
             dev_null.close()

--- a/iotlabsshcli/sshlib/open_a8_ssh.py
+++ b/iotlabsshcli/sshlib/open_a8_ssh.py
@@ -140,6 +140,7 @@ class OpenA8Ssh(object):
 
     def scp(self, src, dst):
         """Copy file to hosts using Parallel SSH copy_file"""
+        result = {"0": [], "1": []}
         sites = ['{}.iot-lab.info'.format(site) for site in self.groups]
         for site in sites:
             try:
@@ -150,7 +151,8 @@ class OpenA8Ssh(object):
                 with SCPClient(ssh.client.get_transport()) as scp:
                     scp.put(src, dst)
                 ssh.client.close()
-        return
+                result["0"].append(site)
+        return _cleanup_result(result)
 
     def wait(self, max_wait):
         """Wait for requested A8 nodes until they boot"""

--- a/iotlabsshcli/sshlib/open_a8_ssh.py
+++ b/iotlabsshcli/sshlib/open_a8_ssh.py
@@ -28,15 +28,6 @@ from pssh.exceptions import AuthenticationException, ConnectionErrorException
 from scp import SCPClient
 
 
-def _node_fqdn(node, site):
-    """Return the fully qualifed domain name of a node.
-
-    >>> _node_fqdn("node-a8-1", "saclay")
-    'node-a8-1.saclay.iot-lab.info'
-    """
-    return '{}.{}.iot-lab.info'.format(node, site)
-
-
 def _cleanup_result(result):
     """Remove empty list from result.
 
@@ -62,15 +53,17 @@ def _cleanup_result(result):
 def _nodes_from_groups(group):
     """Return the full node list from nodes grouped by sites.
 
-    >>> _nodes_from_groups({'saclay': ['node-a8-1', 'node-a8-2'],
-    ...                     'grenoble': ['node-a8-10', 'node-a8-11']})
+    >>> _nodes_from_groups({'saclay': ['node-a8-1.saclay.iot-lab.info',
+    ...                                'node-a8-2.saclay.iot-lab.info'],
+    ...                     'grenoble': ['node-a8-10.grenoble.iot-lab.info',
+    ...                                  'node-a8-11.grenoble.iot-lab.info']})
     ['node-a8-10.grenoble.iot-lab.info', 'node-a8-11.grenoble.iot-lab.info', \
 'node-a8-1.saclay.iot-lab.info', 'node-a8-2.saclay.iot-lab.info']
     """
     result = []
-    for site, nodes in sorted(group.items()):
+    for _, nodes in sorted(group.items()):
         for node in nodes:
-            result.append(_node_fqdn(node, site))
+            result.append(node)
 
     return result
 
@@ -114,26 +107,32 @@ class OpenA8Ssh(object):
         if self.verbose:
             utils.enable_logger(utils.logger)
 
-    def run(self, command, **kwargs):
+    def run(self, command, with_proxy=True, **kwargs):
         """Run ssh command using Parallel SSH."""
         result = {"0": [], "1": []}
         for site in self.groups:
-            client = ParallelSSHClient(self.groups[site],
-                                       user='root',
-                                       proxy_host='{}'
-                                                  '.iot-lab.info'.format(site),
-                                       proxy_user=self.config_ssh['user'])
+            if with_proxy:
+                hosts = self.groups[site]
+                proxy_host = '{}.iot-lab.info'.format(site)
+                client = ParallelSSHClient(hosts,
+                                           user='root',
+                                           proxy_host=proxy_host,
+                                           proxy_user=self.config_ssh['user'])
+            else:
+                hosts = ['{}.iot-lab.info'.format(site)]
+                client = ParallelSSHClient(hosts,
+                                           user=self.config_ssh['user'])
             try:
                 output = client.run_command(command, **kwargs)
                 client.join(output)
             except AuthenticationException:
                 raise OpenA8SshAuthenticationException(site)
             else:
-                for host in self.groups[site]:
-                    result['1' if output[host]['exit_code'] else '0'].append(
-                        '{}.{}.iot-lab.info'.format(host, site))
+                for host in hosts:
+                    result['1' if output[host]['exit_code']
+                           else '0'].append(host)
                 if self.verbose:
-                    for host in self.groups[site]:
+                    for host in hosts:
                         for _ in output[host]['stdout']:
                             pass
         return _cleanup_result(result)
@@ -164,10 +163,10 @@ class OpenA8Ssh(object):
                not _check_all_nodes_processed(whole_nodes, result)):
             for site, nodes in sorted(self.groups.items()):
                 for node in nodes:
-                    if _node_fqdn(node, site) in result["0"]:
+                    if node in result["0"]:
                         continue
                     if self._try_connection(node, site):
-                        result["0"].append(_node_fqdn(node, site))
+                        result["0"].append(node)
             time.sleep(2)
         for node in whole_nodes:
             if node not in result["0"]:
@@ -188,12 +187,12 @@ class OpenA8Ssh(object):
         except ConnectionErrorException:
             if self.verbose:
                 print("Node {} not ready."
-                      .format(_node_fqdn(node, site)))
+                      .format(node))
         else:
             client.client.close()
             if self.verbose:
                 print("Node {} ready."
-                      .format(_node_fqdn(node, site)))
+                      .format(node))
             result = True
         finally:
             dev_null.close()

--- a/iotlabsshcli/tests/open_a8_parser_test.py
+++ b/iotlabsshcli/tests/open_a8_parser_test.py
@@ -195,7 +195,7 @@ class TestMainNodeParser(MainMock):
     @patch('iotlabsshcli.open_a8.copy_file')
     @patch('iotlabcli.parser.common.list_nodes')
     def test_main_copy_file(self, list_nodes, copy_file):
-        """Run the parser.node.main with run-script subparser function."""
+        """Run the parser.node.main with copy-file subparser function."""
         copy_file.return_value = {'result': 'test'}
         list_nodes.return_value = self._nodes
 

--- a/iotlabsshcli/tests/open_a8_parser_test.py
+++ b/iotlabsshcli/tests/open_a8_parser_test.py
@@ -137,7 +137,15 @@ class TestMainNodeParser(MainMock):
         list_nodes.assert_called_with(self.api, 123, [self._nodes], None)
         run_script.assert_called_with({'user': 'username', 'exp_id': 123},
                                       self._root_nodes,
-                                      'script.sh', verbose=False)
+                                      'script.sh', False, verbose=False)
+
+        args = ['run-script', 'script.sh', '--frontend', '-l',
+                'saclay,a8,1-5']
+        open_a8_parser.main(args)
+        list_nodes.assert_called_with(self.api, 123, [self._nodes], None)
+        run_script.assert_called_with({'user': 'username', 'exp_id': 123},
+                                      self._root_nodes,
+                                      'script.sh', True, verbose=False)
 
         exp_info_res = {"items": [{"network_address": node}
                                   for node in self._nodes]}
@@ -149,7 +157,7 @@ class TestMainNodeParser(MainMock):
             list_nodes.assert_called_with(self.api, 123, None, None)
             run_script.assert_called_with({'user': 'username', 'exp_id': 123},
                                           self._root_nodes,
-                                          'script.sh', verbose=False)
+                                          'script.sh', False, verbose=False)
 
     @patch('iotlabsshcli.open_a8.run_cmd')
     @patch('iotlabcli.parser.common.list_nodes')
@@ -163,7 +171,14 @@ class TestMainNodeParser(MainMock):
         list_nodes.assert_called_with(self.api, 123, [self._nodes], None)
         run_cmd.assert_called_with({'user': 'username', 'exp_id': 123},
                                    self._root_nodes,
-                                   'uname -a', verbose=False)
+                                   'uname -a', False, verbose=False)
+
+        args = ['run-cmd', 'uname -a', '--frontend', '-l', 'saclay,a8,1-5']
+        open_a8_parser.main(args)
+        list_nodes.assert_called_with(self.api, 123, [self._nodes], None)
+        run_cmd.assert_called_with({'user': 'username', 'exp_id': 123},
+                                   self._root_nodes,
+                                   'uname -a', True, verbose=False)
 
         exp_info_res = {"items": [{"network_address": node}
                                   for node in self._nodes]}

--- a/iotlabsshcli/tests/open_a8_parser_test.py
+++ b/iotlabsshcli/tests/open_a8_parser_test.py
@@ -151,6 +151,32 @@ class TestMainNodeParser(MainMock):
                                           self._root_nodes,
                                           'script.sh', verbose=False)
 
+    @patch('iotlabsshcli.open_a8.run_cmd')
+    @patch('iotlabcli.parser.common.list_nodes')
+    def test_main_run_cmd(self, list_nodes, run_cmd):
+        """Run the parser.node.main with run-cmd subparser function."""
+        run_cmd.return_value = {'result': 'test'}
+        list_nodes.return_value = self._nodes
+
+        args = ['run-cmd', 'uname -a', '-l', 'saclay,a8,1-5']
+        open_a8_parser.main(args)
+        list_nodes.assert_called_with(self.api, 123, [self._nodes], None)
+        run_cmd.assert_called_with({'user': 'username', 'exp_id': 123},
+                                   self._root_nodes,
+                                   'uname -a', verbose=False)
+
+        exp_info_res = {"items": [{"network_address": node}
+                                  for node in self._nodes]}
+        with patch.object(self.api, 'get_experiment_info',
+                          Mock(return_value=exp_info_res)):
+            list_nodes.return_value = []
+            args = ['run-cmd', 'uname -a']
+            open_a8_parser.main(args)
+            list_nodes.assert_called_with(self.api, 123, None, None)
+            run_cmd.assert_called_with({'user': 'username', 'exp_id': 123},
+                                       self._root_nodes,
+                                       'uname -a', verbose=False)
+
     def test_main_unknown_function(self):
         """Run the parser.node.main with an unknown function."""
         args = ['unknown-cmd']

--- a/iotlabsshcli/tests/open_a8_ssh_test.py
+++ b/iotlabsshcli/tests/open_a8_ssh_test.py
@@ -29,9 +29,8 @@ from iotlabsshcli.sshlib import OpenA8Ssh, OpenA8SshAuthenticationException
 from iotlabsshcli.sshlib.open_a8_ssh import _nodes_from_groups
 from .compat import patch
 
-_SITES = ['saclay', 'grenoble']
 _NODES = ['a8-{}.{}.iot-lab.info'.format(n, s)
-          for n in range(1, 6) for s in _SITES]
+          for n in range(1, 6) for s in ['saclay', 'grenoble']]
 _ROOT_NODES = ['node-{}'.format(node) for node in _NODES]
 
 
@@ -86,7 +85,7 @@ def test_run_on_frontend(join, run_command):
     run_command.return_value = dict(
         ("{}.iot-lab.info".format(site),
          {'stdout': ['test'], 'exit_code': 0})
-        for site in _SITES)
+        for site in ["saclay", "grenoble"])
 
     node_ssh.run(test_command, with_proxy=False)
 

--- a/iotlabsshcli/tests/open_a8_ssh_test.py
+++ b/iotlabsshcli/tests/open_a8_ssh_test.py
@@ -29,8 +29,9 @@ from iotlabsshcli.sshlib import OpenA8Ssh, OpenA8SshAuthenticationException
 from iotlabsshcli.sshlib.open_a8_ssh import _nodes_from_groups
 from .compat import patch
 
+_SITES = ['saclay', 'grenoble']
 _NODES = ['a8-{}.{}.iot-lab.info'.format(n, s)
-          for n in range(1, 6) for s in ['saclay', 'grenoble']]
+          for n in range(1, 6) for s in _SITES]
 _ROOT_NODES = ['node-{}'.format(node) for node in _NODES]
 
 
@@ -85,7 +86,7 @@ def test_run_on_frontend(join, run_command):
     run_command.return_value = dict(
         ("{}.iot-lab.info".format(site),
          {'stdout': ['test'], 'exit_code': 0})
-        for site in ["saclay", "grenoble"])
+        for site in _SITES)
 
     node_ssh.run(test_command, with_proxy=False)
 

--- a/iotlabsshcli/tests/open_a8_ssh_test.py
+++ b/iotlabsshcli/tests/open_a8_ssh_test.py
@@ -51,7 +51,7 @@ def test_run(join, run_command):
 
     # Print output of run_command
     run_command.return_value = dict(
-        (node.split('.', 1)[0],
+        (node,
          {'stdout': ['test'], 'exit_code': 0})
         for node in _ROOT_NODES)
 

--- a/iotlabsshcli/tests/open_a8_ssh_test.py
+++ b/iotlabsshcli/tests/open_a8_ssh_test.py
@@ -86,7 +86,7 @@ def test_scp(connect, client, put, _open):
     node_ssh = OpenA8Ssh(config_ssh, groups, verbose=True)
     ret = node_ssh.scp(src, dst)
 
-    assert ret is None
+    assert ret == {'0': ['saclay.iot-lab.info', 'grenoble.iot-lab.info']}
 
     # Simulating an exception
     connect.side_effect = AuthenticationException()

--- a/iotlabsshcli/tests/open_a8_test.py
+++ b/iotlabsshcli/tests/open_a8_test.py
@@ -107,7 +107,7 @@ def test_open_a8_wait_for_boot(wait):
 @patch('iotlabsshcli.sshlib.OpenA8Ssh.run')
 @patch('iotlabsshcli.sshlib.OpenA8Ssh.scp')
 def test_open_a8_run_script(scp, run):
-    """Test flashing an M3."""
+    """Test run script on A8 nodes."""
     config_ssh = {
         'user': 'username',
         'exp_id': 123,

--- a/iotlabsshcli/tests/open_a8_test.py
+++ b/iotlabsshcli/tests/open_a8_test.py
@@ -23,6 +23,7 @@
 
 import os.path
 from iotlabsshcli.open_a8 import reset_m3, flash_m3, wait_for_boot, run_script
+from iotlabsshcli.open_a8 import run_cmd
 from iotlabsshcli.open_a8 import (_RESET_M3_CMD, _UPDATE_M3_CMD,
                                   _MKDIR_DST_CMD, _RUN_SCRIPT_CMD,
                                   _QUIT_SCRIPT_CMD, _MAKE_EXECUTABLE_CMD)
@@ -140,3 +141,23 @@ def test_open_a8_run_script(scp, run):
     run.side_effect = OpenA8SshAuthenticationException('test')
     ret = run_script(config_ssh, _ROOT_NODES, script)
     assert ret == {'run-script': {'1': _ROOT_NODES}}
+
+
+@patch('iotlabsshcli.sshlib.OpenA8Ssh.run')
+def test_open_a8_run_cmd(run):
+    """Test run command on A8 nodes."""
+    config_ssh = {
+        'user': 'username',
+        'exp_id': 123,
+    }
+    cmd = 'uname -a'
+    return_value = {'0': 'test'}
+    run.return_value = return_value
+
+    ret = run_cmd(config_ssh, _ROOT_NODES, cmd)
+    assert ret == {'run-cmd': return_value}
+
+    # Raise an exception
+    run.side_effect = OpenA8SshAuthenticationException('test')
+    ret = run_cmd(config_ssh, _ROOT_NODES, cmd)
+    assert ret == {'run-cmd': {'1': _ROOT_NODES}}

--- a/iotlabsshcli/tests/open_a8_test.py
+++ b/iotlabsshcli/tests/open_a8_test.py
@@ -122,7 +122,7 @@ def test_open_a8_run_script(scp, run):
     return_value = {'0': 'test'}
     run.return_value = return_value
 
-    ret = run_script(config_ssh, _ROOT_NODES, script)
+    ret = run_script(config_ssh, _ROOT_NODES, script, False)
 
     assert ret == {'run-script': return_value}
     scp.assert_called_once_with(script, remote_script)
@@ -182,10 +182,10 @@ def test_open_a8_run_cmd(run):
     return_value = {'0': 'test'}
     run.return_value = return_value
 
-    ret = run_cmd(config_ssh, _ROOT_NODES, cmd)
+    ret = run_cmd(config_ssh, _ROOT_NODES, cmd, False)
     assert ret == {'run-cmd': return_value}
 
     # Raise an exception
     run.side_effect = OpenA8SshAuthenticationException('test')
-    ret = run_cmd(config_ssh, _ROOT_NODES, cmd)
+    ret = run_cmd(config_ssh, _ROOT_NODES, cmd, False)
     assert ret == {'run-cmd': {'1': _ROOT_NODES}}

--- a/iotlabsshcli/tests/open_a8_test.py
+++ b/iotlabsshcli/tests/open_a8_test.py
@@ -122,7 +122,7 @@ def test_open_a8_run_script(scp, run):
     return_value = {'0': 'test'}
     run.return_value = return_value
 
-    ret = run_script(config_ssh, _ROOT_NODES, script, False)
+    ret = run_script(config_ssh, _ROOT_NODES, script)
 
     assert ret == {'run-script': return_value}
     scp.assert_called_once_with(script, remote_script)
@@ -139,7 +139,7 @@ def test_open_a8_run_script(scp, run):
 
     # Raise an exception
     run.side_effect = OpenA8SshAuthenticationException('test')
-    ret = run_script(config_ssh, _ROOT_NODES, script, False)
+    ret = run_script(config_ssh, _ROOT_NODES, script)
     assert ret == {'run-script': {'1': _ROOT_NODES}}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands=
 
 [testenv:tests]
 commands=
-    pytest --doctest-modules iotlabsshcli --cov=iotlabsshcli
+    pytest -v --doctest-modules iotlabsshcli --cov=iotlabsshcli
 
 [testenv:lint]
 commands=


### PR DESCRIPTION
+ Add with_proxy option in ssh lib run command. With with_proxy option you execute the command
on the A8 nodes otherwise on the SSH frontend only at once.

+ Add two parser commands:
run-cmd : execute a command on the A8 nodes or frontend SSH (--frontend option)
copy-file : copy a file on the SSH frontend homedir directory (~/A8/.iotlabsshcli)

+ Modify run-script/flash-m3 command when with_proxy option is needed. (create
directory or change permissions on the SSH frontend)

+ Add --frontend option for run-script command.
