### PR TITLE
simplify travis file, run codecov from tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,26 +3,19 @@ language: python
 matrix:
     include:
         - python: 2.7
-          env:
-            - TOX_ENV="py27-tests,py27-lint,cli"
-            - COVERAGE="true"
+          env: TOXENV="py27-tests,py27-lint,cli,coverage"
         - python: 3.4
-          env: TOX_ENV="py34-tests,cli"
+          env: TOXENV="py34-tests,cli"
         - python: 3.5
-          env:
-            - TOX_ENV="copying,py35-tests,py35-lint,cli"
-            - COVERAGE="true"
+          env: TOXENV="copying,py35-tests,py35-lint,cli,coverage"
         - python: 3.6
-          env: TOX_ENV="py36-tests,cli"
+          env: TOXENV="py36-tests,cli"
 
 before_install:
-    - pip install tox codecov
+    - pip install tox
 
 install:
     - pip install .
 
 script:
-    - tox -e ${TOX_ENV}
-
-after_success:
-    - if [ ! -z ${COVERAGE+x} ]; then echo "Running codecov" && codecov; fi
+    - tox

--- a/tests_utils/coverage-python-3.2.txt
+++ b/tests_utils/coverage-python-3.2.txt
@@ -1,3 +1,0 @@
-# Drop support for python3.2
-# https://bitbucket.org/ned/coveragepy/issues/407/coverage-failing-on-python-325-using
-coverage < 4.0.0

--- a/tests_utils/pylint-python-2.6_3.2.txt
+++ b/tests_utils/pylint-python-2.6_3.2.txt
@@ -1,4 +1,0 @@
-# Not using '2to3' anymore, pylint 1.4 breaks python 2.6 compatibility
-pylint<1.4.0
-logilab-common<0.63
-astroid<1.3.0

--- a/tests_utils/test-requirements.txt
+++ b/tests_utils/test-requirements.txt
@@ -6,3 +6,4 @@ setuptools-pep8
 setuptools-lint
 # issues with pep8 >= 1.6
 flake8==2.3.0
+codecov>=1.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,10 @@ whitelist_externals =
 deps=
     -rtests_utils/test-requirements.txt
 commands=
-    tests: {[testenv:tests]commands}
-    lint:  {[testenv:lint]commands}
-    cli:   {[testenv:cli]commands}
+    tests:   {[testenv:tests]commands}
+    lint:    {[testenv:lint]commands}
+    cli:     {[testenv:cli]commands}
+    coverage: {[testenv:coverage]commands}
 
 [testenv:tests]
 commands=
@@ -33,3 +34,7 @@ commands=
 whitelist_externals = /bin/bash
 commands=
     bash -exc "for i in *-cli; do $i --help >/dev/null; done"
+
+[testenv:coverage]
+passenv = CI TRAVIS TRAVIS_*
+commands = codecov -e TOXENV


### PR DESCRIPTION
This is a test PR trying to simplify the travis configuration file and run codecov from a tox testenv.