### PR TITLE
Refactor parallel-ssh library

### DIFF
--- a/iotlabsshcli/sshlib/open_a8_ssh.py
+++ b/iotlabsshcli/sshlib/open_a8_ssh.py
@@ -199,13 +199,11 @@ class OpenA8Ssh(object):
         """Run ssh command using Parallel SSH."""
         result = {"0": [], "1": []}
         if proxy_host:
-            client = ParallelSSHClient(hosts,
-                                       user='root',
+            client = ParallelSSHClient(hosts, user='root',
                                        proxy_host=proxy_host,
                                        proxy_user=user)
         else:
-            client = ParallelSSHClient(hosts,
-                                       user=user)
+            client = ParallelSSHClient(hosts, user=user)
         output = client.run_command(command, stop_on_errors=False,
                                     **kwargs)
         client.join(output)

--- a/iotlabsshcli/sshlib/open_a8_ssh.py
+++ b/iotlabsshcli/sshlib/open_a8_ssh.py
@@ -54,33 +54,46 @@ def _extend_result(result, new_result):
     """ Extend result dictionnary values with new result
     dictionnary values
 
-    >>> sorted(_extend_result(
-    ...    { '0': [], '1': []}, { '0': [], '1': []}).items())
-    [('0', []), ('1', [])]
-    >>> sorted(_extend_result(
-    ...    { '0': [], '1': []},
-    ...    { '0': ['node-a8-1.saclay.iot-lab.info'], '1': []}).items())
-    [('0', ['node-a8-1.saclay.iot-lab.info']), ('1', [])]
-    >>> sorted(_extend_result(
+    >>> result = {'0': [], '1': []}
+    >>> result == _extend_result(
+    ...    { '0': [], '1': []}, { '0': [], '1': []})
+    True
+
+    >>> result = {'0': ['node-a8-1.saclay.iot-lab.info'],
+    ...           '1': []}
+    >>> result == _extend_result({ '0': [], '1': []},
+    ...    { '0': ['node-a8-1.saclay.iot-lab.info'], '1': []})
+    True
+
+    >>> result = {'0': ['node-a8-1.saclay.iot-lab.info',
+    ...                 'node-a8-2.saclay.iot-lab.info'],
+    ...           '1': ['node-a8-3.saclay.iot-lab.info']}
+    >>> result == _extend_result(
     ...    { '0': ['node-a8-1.saclay.iot-lab.info'], '1': []},
     ...    { '0': ['node-a8-2.saclay.iot-lab.info'],
-    ...      '1': ['node-a8-3.saclay.iot-lab.info']}).items())
-    [('0', ['node-a8-1.saclay.iot-lab.info', \
-'node-a8-2.saclay.iot-lab.info']), ('1', ['node-a8-3.saclay.iot-lab.info'])]
-    >>> sorted(_extend_result(
+    ...      '1': ['node-a8-3.saclay.iot-lab.info']})
+    True
+
+    >>> result = {'0': ['node-a8-1.saclay.iot-lab.info',
+    ...                 'node-a8-2.saclay.iot-lab.info'],
+    ...           '1': ['node-a8-3.saclay.iot-lab.info']}
+    >>> result ==_extend_result(
     ...    { '0': ['node-a8-1.saclay.iot-lab.info',
-    ...      'node-a8-2.saclay.iot-lab.info'],
+    ...            'node-a8-2.saclay.iot-lab.info'],
     ...      '1': ['node-a8-3.saclay.iot-lab.info']},
-    ...    { '0': [], '1': ['node-a8-3.saclay.iot-lab.info']}).items())
-    [('0', ['node-a8-1.saclay.iot-lab.info', \
-'node-a8-2.saclay.iot-lab.info']), ('1', ['node-a8-3.saclay.iot-lab.info'])]
-    >>> sorted(_extend_result(
+    ...    { '0': [], '1': ['node-a8-3.saclay.iot-lab.info']})
+    True
+
+    >>> result =  {'0': ['node-a8-1.saclay.iot-lab.info',
+    ...                  'node-a8-2.saclay.iot-lab.info',
+    ...                  'node-a8-3.saclay.iot-lab.info'],
+    ...            '1': []}
+    >>> result == _extend_result(
     ...    { '0': ['node-a8-1.saclay.iot-lab.info',
-    ...      'node-a8-2.saclay.iot-lab.info'],
+    ...            'node-a8-2.saclay.iot-lab.info'],
     ...      '1': ['node-a8-3.saclay.iot-lab.info']},
-    ...    { '0': ['node-a8-3.saclay.iot-lab.info'], '1': []}).items())
-    [('0', ['node-a8-1.saclay.iot-lab.info', 'node-a8-2.saclay.iot-lab.info', \
-'node-a8-3.saclay.iot-lab.info']), ('1', [])]
+    ...    { '0': ['node-a8-3.saclay.iot-lab.info'], '1': []})
+    True
     """
     result["0"] = sorted(list(set(result["0"] + new_result["0"])))
     result["1"] = sorted(list(set(result["1"]) - set(new_result["0"])))
@@ -102,10 +115,7 @@ def _check_all_nodes_processed(result):
     ...      'grenoble': ['node-a8-10.grenoble.iot-lab.info']})
     False
     """
-    for nodes in result.values():
-        if nodes:
-            return False
-    return True
+    return not any(result.values())
 
 
 class OpenA8SshAuthenticationException(Exception):

--- a/iotlabsshcli/tests/open_a8_ssh_test.py
+++ b/iotlabsshcli/tests/open_a8_ssh_test.py
@@ -148,3 +148,35 @@ def test_wait_all_boot(join, run_command):
     run_command.call_count = len(_ROOT_NODES)
     run_command.assert_called_with(test_command,
                                    stop_on_errors=False)
+
+
+@patch('pssh.ParallelSSHClient.run_command')
+@patch('pssh.ParallelSSHClient.join')
+def test_authentication_exception(join, run_command):
+    # pylint: disable=unused-argument
+    """Test SSH authentication exception with parallel-ssh
+    run_command and stop_on_errors=False option.
+    """
+    config_ssh = {
+        'user': 'username',
+        'exp_id': 123,
+    }
+
+    test_command = 'test'
+    groups = _nodes_grouped(_ROOT_NODES)
+
+    # normal boot
+    node_ssh = OpenA8Ssh(config_ssh, groups, verbose=True)
+
+    # Print output of run_command
+    run_command.return_value = dict(
+        ("{}.iot-lab.info".format(site),
+         {'stdout': None, 'exit_code': None})
+        for site in _SITES)
+
+    with raises(OpenA8SshAuthenticationException):
+        node_ssh.run(test_command)
+
+    run_command.call_count = len(_ROOT_NODES)
+    run_command.assert_called_with(test_command,
+                                   stop_on_errors=False)

--- a/iotlabsshcli/tests/open_a8_ssh_test.py
+++ b/iotlabsshcli/tests/open_a8_ssh_test.py
@@ -64,8 +64,7 @@ def test_run(join, run_command, run_on_frontend):
 
     node_ssh.run(test_command, with_proxy=not run_on_frontend)
     assert run_command.call_count == len(groups)
-    run_command.assert_called_with(test_command,
-                                   stop_on_errors=False)
+    run_command.assert_called_with(test_command, stop_on_errors=False)
 
 
 @patch('scp.SCPClient._open')

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def get_version(package):
 
 SCRIPTS = ['open-a8-cli']
 
-INSTALL_REQUIRES = ['argparse', 'iotlabcli>=2.0', 'parallel-ssh>=0.94',
+INSTALL_REQUIRES = ['argparse', 'iotlabcli>=2.0', 'parallel-ssh>=1.0.0',
                     'scp>=0.10', 'gevent<=1.1']
 
 setup(


### PR DESCRIPTION
* add run_command static method class:
     * ParallelSSHClient with run_command (optionnal proxy host option)
     * use stop_on_errors option and manage Exceptions in output structure
* run and wait-for-boot command:
     * use run_command method
     * share result structure generation (_extends_result method)
 * catch ConnectionErrorException in scp method
 * modify ssh lib tests accordingly
