### PR TITLE
rename open-a8-cli into Iotlab-ssh

### DIFF
--- a/iotlab-ssh
+++ b/iotlab-ssh
@@ -20,7 +20,4 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 import iotlabsshcli.parser.open_a8_parser
-from iotlabcli.helpers import deprecate_cmd
-
-deprecate_cmd(iotlabsshcli.parser.open_a8_parser.main,
-              "open-a8-cli", "iotlab-ssh")
+iotlabsshcli.parser.open_a8_parser.main()

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,10 @@ def get_version(package):
                 return eval(line.split('=')[-1])  # pylint:disable=eval-used
 
 
-SCRIPTS = ['open-a8-cli']
+SCRIPTS = ['iotlab-ssh']
+DEPRECATED_SCRIPTS = ['open-a8-cli']
+
+SCRIPTS += DEPRECATED_SCRIPTS
 
 INSTALL_REQUIRES = ['argparse', 'iotlabcli>=2.0', 'parallel-ssh>=1.2.0',
                     'scp>=0.10', 'gevent<=1.1']

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,8 @@ commands=
 [testenv:cli]
 whitelist_externals = /bin/bash
 commands=
-    bash -exc "for i in *-cli; do $i --help >/dev/null; done"
+    bash -exc "open-a8-cli --help >/dev/null"
+    bash -exc "iotlab-ssh --help > /dev/null"
 
 [testenv:coverage]
 passenv = CI TRAVIS TRAVIS_*


### PR DESCRIPTION
Existing command open-a8-cli is kept but it raises a deprecation warning when used.

This branch needs a specific branch from cli-tools to works (see 0c01c20). This commit should be removed when https://github.com/iot-lab/cli-tools/pull/14 is merged.