### PR TITLE
Fix --jmespath and --format options not taken into account

### DIFF
--- a/iotlabsshcli/parser/open_a8_parser.py
+++ b/iotlabsshcli/parser/open_a8_parser.py
@@ -35,7 +35,6 @@ def parse_options():
     """Parse command line option."""
     parent_parser = argparse.ArgumentParser(add_help=False)
     common.add_auth_arguments(parent_parser, False)
-    common.add_output_formatter(parent_parser)
     parent_parser.add_argument('-v', '--version',
                                action='version',
                                version=iotlabsshcli.__version__)
@@ -46,6 +45,7 @@ def parse_options():
     )
 
     common.add_expid_arg(parser)
+    common.add_output_formatter(parser)
 
     subparsers = parser.add_subparsers(dest='command')
     subparsers.required = True  # needed for python 3.

--- a/iotlabsshcli/tests/open_a8_parser_test.py
+++ b/iotlabsshcli/tests/open_a8_parser_test.py
@@ -21,6 +21,8 @@
 
 """Tests for iotlabsshcli.parser.open_a8 package."""
 
+import jmespath
+
 from iotlabsshcli.parser import open_a8_parser
 
 from .iotlabsshcli_mock import MainMock
@@ -229,3 +231,31 @@ class TestMainNodeParser(MainMock):
         parser = open_a8_parser.parse_options()
         self.assertRaises(TypeError, open_a8_parser.open_a8_parse_and_run,
                           parser, args)
+
+    @patch('iotlabsshcli.open_a8.reset_m3')
+    @patch('iotlabcli.parser.common.list_nodes')
+    @patch('iotlabcli.parser.common.print_result')
+    def test_reset_m3_jmespath(self, print_result, list_nodes, reset_m3):
+        """Run reset-m3 subparser function with jmespath options."""
+        reset_m3.return_value = {'result': 'test'}
+        list_nodes.return_value = self._nodes
+
+        args = ['--jmespath=\'test\'', '--fmt=\'int\'', 'reset-m3',
+                '-l', 'saclay,a8,1-5']
+        open_a8_parser.main(args)
+
+        print_result.assert_called_once()
+        args, _ = print_result.call_args
+        self.assertEqual(len(args), 3)
+        self.assertEqual(args[0], {'result': 'test'})
+        self.assertTrue(isinstance(args[1], jmespath.parser.ParsedResult))
+        self.assertEqual(args[2], 'int')
+
+        args = ['reset-m3', '-l', 'saclay,a8,1-5']
+        open_a8_parser.main(args)
+        print_result.assert_called_once()
+        args, _ = print_result.call_args
+        self.assertEqual(len(args), 3)
+        self.assertEqual(args[0], {'result': 'test'})
+        self.assertEqual(args[1], None)
+        self.assertEqual(args[2], None)


### PR DESCRIPTION
This PR is providing a fix for #35.

The fix consists in attaching the output formatter parser to the right top level parser and to directly import the `add_output_formatter` function from `iotlabcli.common`. There was a namespace issue with argparse that was skipping jmespath and format option (this is still unclear for me).

A non regression tests is also added: it checks that `print_result` is called with the right parameters when using `--jmespath` and `--format` options.

By the way, the `--jmespath` option given as example in #35 should be:
```
iotlab-ssh --jmespath='keys(values(@)[0])[0]' --fmt='int' reset-m3 --list lyon,a8,1
```

Otherwise, it doesn't work.