### PR TITLE
MAINT: various updates and enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 
 matrix:
     include:
@@ -10,6 +11,8 @@ matrix:
           env: TOXENV="copying,py35-tests,py35-lint,cli,coverage"
         - python: 3.6
           env: TOXENV="py36-tests,cli"
+        - python: 3.7
+          env: TOXENV="py37-tests,cli"
 
 before_install:
     - sudo apt-get install libssh2-1-dev -y

--- a/iotlabsshcli/parser/open_a8_parser.py
+++ b/iotlabsshcli/parser/open_a8_parser.py
@@ -139,32 +139,36 @@ def open_a8_parse_and_run(opts):
              for node in nodes if node.startswith('a8')]
 
     command = opts.command
+    res = None
     if command == 'reset-m3':
-        return iotlabsshcli.open_a8.reset_m3(config_ssh, nodes,
-                                             verbose=opts.verbose)
-    elif command == 'flash-m3':
-        return iotlabsshcli.open_a8.flash_m3(config_ssh, nodes, opts.firmware,
-                                             verbose=opts.verbose)
-    elif command == 'wait-for-boot':
-        return iotlabsshcli.open_a8.wait_for_boot(config_ssh, nodes,
-                                                  max_wait=opts.max_wait,
-                                                  verbose=opts.verbose)
-    elif command == 'run-script':
-        return iotlabsshcli.open_a8.run_script(config_ssh, nodes,
-                                               opts.script,
-                                               opts.frontend,
-                                               verbose=opts.verbose)
-    elif command == 'run-cmd':
-        return iotlabsshcli.open_a8.run_cmd(config_ssh, nodes,
-                                            opts.cmd,
-                                            opts.frontend,
+        res = iotlabsshcli.open_a8.reset_m3(config_ssh, nodes,
                                             verbose=opts.verbose)
-    elif command == 'copy-file':
-        return iotlabsshcli.open_a8.copy_file(config_ssh, nodes,
-                                              opts.file_path,
+    elif command == 'flash-m3':
+        res = iotlabsshcli.open_a8.flash_m3(config_ssh, nodes, opts.firmware,
+                                            verbose=opts.verbose)
+    elif command == 'wait-for-boot':
+        res = iotlabsshcli.open_a8.wait_for_boot(config_ssh, nodes,
+                                                 max_wait=opts.max_wait,
+                                                 verbose=opts.verbose)
+    elif command == 'run-script':
+        res = iotlabsshcli.open_a8.run_script(config_ssh, nodes,
+                                              opts.script,
+                                              opts.frontend,
                                               verbose=opts.verbose)
-    else:  # pragma: no cover
+    elif command == 'run-cmd':
+        res = iotlabsshcli.open_a8.run_cmd(config_ssh, nodes,
+                                           opts.cmd,
+                                           opts.frontend,
+                                           verbose=opts.verbose)
+    elif command == 'copy-file':
+        res = iotlabsshcli.open_a8.copy_file(config_ssh, nodes,
+                                             opts.file_path,
+                                             verbose=opts.verbose)
+
+    if res is None:
         raise ValueError('Unknown command {0}'.format(command))
+
+    return res
 
 
 def main(args=None):

--- a/iotlabsshcli/sshlib/open_a8_ssh.py
+++ b/iotlabsshcli/sshlib/open_a8_ssh.py
@@ -130,7 +130,7 @@ class OpenA8SshAuthenticationException(Exception):
         self.msg = msg
 
 
-class OpenA8Ssh(object):
+class OpenA8Ssh():
     """Implement SshAPI for Parallel SSH."""
 
     def __init__(self, config_ssh, groups, verbose=False):

--- a/iotlabsshcli/tests/iotlabsshcli_mock.py
+++ b/iotlabsshcli/tests/iotlabsshcli_mock.py
@@ -33,7 +33,7 @@ from .compat import patch, Mock
 API_RET = {"result": "test"}
 
 
-class RequestRet(object):  # pylint:disable=too-few-public-methods
+class RequestRet():  # pylint:disable=too-few-public-methods
     """ Mock of Request return value """
 
     def __init__(self, status_code, content, headers=None):

--- a/iotlabsshcli/tests/open_a8_parser_test.py
+++ b/iotlabsshcli/tests/open_a8_parser_test.py
@@ -225,12 +225,19 @@ class TestMainNodeParser(MainMock):
         args = ['unknown-cmd']
         self.assertRaises(SystemExit, open_a8_parser.main, args)
 
-    def test_run_unknown_function(self):
+    @patch('iotlabcli.parser.common.list_nodes')
+    def test_run_unknown_function(self, list_nodes):
+        # pylint:disable=unused-argument
         """Run the parser.node.main with an unknown function."""
-        args = ['unknown-cmd']
         parser = open_a8_parser.parse_options()
-        self.assertRaises(TypeError, open_a8_parser.open_a8_parse_and_run,
-                          parser, args)
+        parser.command = 'unknown-cmd'
+        parser.username = 'username'
+        parser.password = 'password'
+        parser.experiment_id = 'experiment_id'
+        parser.nodes_list = []
+        parser.exclude_nodes_list = []
+        self.assertRaises(ValueError,
+                          open_a8_parser.open_a8_parse_and_run, parser)
 
     @patch('iotlabsshcli.open_a8.reset_m3')
     @patch('iotlabcli.parser.common.list_nodes')

--- a/iotlabsshcli/tests/open_a8_ssh_test.py
+++ b/iotlabsshcli/tests/open_a8_ssh_test.py
@@ -35,8 +35,8 @@ _ROOT_NODES = ['node-{}'.format(node) for node in _NODES]
 
 
 @mark.parametrize('run_on_frontend', [False, True])
-@patch('pssh.clients.native.ParallelSSHClient.run_command')
-@patch('pssh.clients.native.ParallelSSHClient.join')
+@patch('pssh.clients.ParallelSSHClient.run_command')
+@patch('pssh.clients.ParallelSSHClient.join')
 def test_run(join, run_command, run_on_frontend):
     # pylint: disable=unused-argument
     """Test running commands on ssh nodes."""
@@ -69,8 +69,8 @@ def test_run(join, run_command, run_on_frontend):
 
 @patch('scp.SCPClient._open')
 @patch('scp.SCPClient.put')
-@patch('pssh.clients.miko.SSHClient')
-@patch('pssh.clients.miko.SSHClient._connect')
+@patch('paramiko.SSHClient')
+@patch('paramiko.SSHClient.connect')
 def test_scp(connect, client, put, _open):
     # pylint: disable=unused-argument
     """Test wait for ssh nodes to be available."""
@@ -102,8 +102,8 @@ def test_scp(connect, client, put, _open):
         node_ssh.scp(src, dst)
 
 
-@patch('pssh.clients.native.ParallelSSHClient.run_command')
-@patch('pssh.clients.native.ParallelSSHClient.join')
+@patch('pssh.clients.ParallelSSHClient.run_command')
+@patch('pssh.clients.ParallelSSHClient.join')
 def test_wait_all_boot(join, run_command):
     # pylint: disable=unused-argument
     """Test wait for ssh nodes to be available."""
@@ -134,8 +134,8 @@ def test_wait_all_boot(join, run_command):
     run_command.assert_called_with(test_command, stop_on_errors=False)
 
 
-@patch('pssh.clients.native.ParallelSSHClient.run_command')
-@patch('pssh.clients.native.ParallelSSHClient.join')
+@patch('pssh.clients.ParallelSSHClient.run_command')
+@patch('pssh.clients.ParallelSSHClient.join')
 def test_authentication_exception(join, run_command):
     # pylint: disable=unused-argument
     """Test SSH authentication exception with parallel-ssh

--- a/iotlabsshcli/tests/open_a8_test.py
+++ b/iotlabsshcli/tests/open_a8_test.py
@@ -23,6 +23,7 @@
 
 import os.path
 from pytest import mark
+
 from iotlabsshcli.open_a8 import reset_m3, flash_m3, wait_for_boot, run_script
 from iotlabsshcli.open_a8 import run_cmd, copy_file
 from iotlabsshcli.open_a8 import (_RESET_M3_CMD, _UPDATE_M3_CMD,

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 addopts =
     -v
     --doctest-modules
-    --cov=iotlabsshcli
+    --cov iotlabsshcli
     --cov-report term-missing
 testpaths = iotlabsshcli
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ testpaths = iotlabsshcli
 
 [lint]
 lint-reports = no
-lint-disable = locally-disabled,star-args,bad-option-value
+lint-disable = locally-disabled,star-args,bad-option-value,old-style-class
 lint-msg-template = {path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
 
 [pep8]

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
                  'Programming Language :: Python :: 3.4',
                  'Programming Language :: Python :: 3.5',
                  'Programming Language :: Python :: 3.6',
+                 'Programming Language :: Python :: 3.7',
                  'Intended Audience :: End Users/Desktop',
                  'Environment :: Console',
                  'Topic :: Utilities', ],

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ DEPRECATED_SCRIPTS = ['open-a8-cli']
 SCRIPTS += DEPRECATED_SCRIPTS
 
 INSTALL_REQUIRES = ['argparse', 'iotlabcli>=2.0', 'parallel-ssh>=1.6.0',
-                    'scp==0.11', 'gevent<=1.1']
+                    'scp==0.11', 'gevent']
 
 setup(
     name=PACKAGE,

--- a/tests_utils/test-requirements.txt
+++ b/tests_utils/test-requirements.txt
@@ -4,8 +4,7 @@ pytest-cov
 mock <= 1.0.1
 setuptools-pep8
 setuptools-lint
-# issues with setuptools-lint
-pylint>=1.8,<2
+pylint
 # issues with pep8 >= 1.6
 flake8==2.3.0
 codecov>=1.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = copying,{py27,py35}-{lint,tests},cli
+envlist = copying,{py27,py35,py36,py37}-{lint,tests},cli
 
 [tox:jenkins]
 skip_missing_interpreters = True


### PR DESCRIPTION
This PR does several updates:
- add support for python 3.7 in the CI tools (Tox and Travis)
- remove the pylint version limitation and fix pending pylint issues
- fix the use of parallel-ssh client classes: use native parallel ssh client (recommended and faster) directly use the paramiko sshclient (only used for copying files)
- the previous point has several positive consequences:
  - there was a userwarning message displayed when running the cli, this warning is gone
  - the code coverage of tests was returning weird missed lines, this is also fixed (apparently parallel-ssh paramiko monkey patch has side-effect)