### PR TITLE
Bump to Parallel-ssh version 2

### DIFF
--- a/iotlabsshcli/open_a8.py
+++ b/iotlabsshcli/open_a8.py
@@ -47,7 +47,6 @@ def _nodes_grouped(nodes):
             result.update({site: [host]})
         else:
             result[site].append(host)
-
     return result
 
 
@@ -61,7 +60,7 @@ _REMOTE_A8_DIR = 'A8/.iotlabsshcli'
 
 
 def flash_m3(config_ssh, nodes, firmware, verbose=False):
-    """ Flash the firmware of M3 co-microcontroller """
+    """Flash the firmware of M3 co-microcontroller """
     failed_hosts = []
     # configure ssh and remote firmware names.
     groups = _nodes_grouped(nodes)
@@ -81,7 +80,7 @@ def flash_m3(config_ssh, nodes, firmware, verbose=False):
 
 
 def reset_m3(config_ssh, nodes, verbose=False):
-    """ Reset M3 co-microcontroller """
+    """Reset M3 co-microcontroller """
 
     # Configure ssh
     groups = _nodes_grouped(nodes)
@@ -91,7 +90,7 @@ def reset_m3(config_ssh, nodes, verbose=False):
 
 
 def wait_for_boot(config_ssh, nodes, max_wait=120, verbose=False):
-    """ Wait for the open A8 nodes boot """
+    """Wait for the open A8 nodes boot """
 
     # Configure ssh.
     groups = _nodes_grouped(nodes)
@@ -101,7 +100,7 @@ def wait_for_boot(config_ssh, nodes, max_wait=120, verbose=False):
 
 
 def run_cmd(config_ssh, nodes, cmd, run_on_frontend=False, verbose=False):
-    """ Run a command on the A8 nodes or SSH frontend servers """
+    """Run a command on the A8 nodes or SSH frontend servers """
 
     # Configure ssh.
     groups = _nodes_grouped(nodes)
@@ -110,7 +109,7 @@ def run_cmd(config_ssh, nodes, cmd, run_on_frontend=False, verbose=False):
 
 
 def copy_file(config_ssh, nodes, file_path, verbose=False):
-    """ copy a file to SSH frontend servers """
+    """Copy a file to SSH frontend servers """
 
     # Configure ssh.
     groups = _nodes_grouped(nodes)
@@ -122,12 +121,12 @@ def copy_file(config_ssh, nodes, file_path, verbose=False):
 
 
 def _get_failed_result(groups, result, run_on_frontend):
-    """ Returns the list of nodes or SSH frontend servers that failed with
-        the execution of the command. We delete failed hosts for the next
-        commands
+    """Returns failed nodes or SSH frontend servers list.
+
+    We delete failed hosts for the next commands in the groups
     """
     failed = []
-    if '1' in result:
+    if '1' in result and result['1']:
         if not run_on_frontend:
             # nodes list
             for site in result['1']:
@@ -142,7 +141,7 @@ def _get_failed_result(groups, result, run_on_frontend):
 
 def run_script(config_ssh, nodes, script, run_on_frontend=False,
                verbose=False):
-    """ Run a script in background on A8 nodes or SSH frontend servers """
+    """Run a script in background on A8 nodes or SSH frontend servers """
 
     # Configure ssh.
     failed_hosts = []

--- a/iotlabsshcli/open_a8.py
+++ b/iotlabsshcli/open_a8.py
@@ -75,7 +75,7 @@ def flash_m3(config_ssh, nodes, firmware, verbose=False):
     # Run firmware update.
     result = ssh.run(_UPDATE_M3_CMD.format(remote_fw))
     for hosts in failed_hosts:
-        result.get('1', []).extend(hosts)
+        result.setdefault('1', []).extend(hosts)
     return {"flash-m3": result}
 
 
@@ -165,6 +165,6 @@ def run_script(config_ssh, nodes, script, run_on_frontend=False,
     # Run script
     result = ssh.run(_RUN_SCRIPT_CMD.format(**script_data),
                      with_proxy=not run_on_frontend, use_pty=False)
-    for hosts in failed_hosts:
-        result.get('1', []).extend(hosts)
+    for hosts in filter(None, failed_hosts):
+        result.setdefault('1', []).extend(hosts)
     return {"run-script": result}

--- a/iotlabsshcli/sshlib/__init__.py
+++ b/iotlabsshcli/sshlib/__init__.py
@@ -22,4 +22,4 @@
 
 # flake8: noqa
 
-from .open_a8_ssh import OpenA8Ssh, OpenA8SshAuthenticationException
+from .open_a8_ssh import OpenA8Ssh

--- a/iotlabsshcli/sshlib/open_a8_ssh.py
+++ b/iotlabsshcli/sshlib/open_a8_ssh.py
@@ -21,14 +21,12 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 
-from __future__ import print_function
 import time
-import paramiko
-from paramiko import SSHClient
+from pssh.clients import SSHClient
 from pssh.clients import ParallelSSHClient
+from pssh.exceptions import SFTPError, UnknownHostError
+from pssh.exceptions import ConnectionError, AuthenticationError
 from pssh import utils
-from pssh.exceptions import AuthenticationException, ConnectionErrorException
-from scp import SCPClient
 
 
 def _cleanup_result(result):
@@ -121,18 +119,8 @@ def _check_all_nodes_processed(result):
     return not any(result.values())
 
 
-class OpenA8SshAuthenticationException(Exception):
-    """Raised when an authentication error occurs on one site"""
-
-    def __init__(self, site):
-        msg = ('Cannot connect to IoT-LAB server on site '
-               '"{}", check your SSH configuration.'.format(site))
-        super(OpenA8SshAuthenticationException, self).__init__(msg)
-        self.msg = msg
-
-
 class OpenA8Ssh():
-    """Implement SshAPI for Parallel SSH."""
+    """ Implement SSH API for Parallel SSH."""
 
     def __init__(self, config_ssh, groups, verbose=False):
         self.config_ssh = config_ssh
@@ -143,11 +131,11 @@ class OpenA8Ssh():
             utils.enable_logger(utils.logger)
 
     def run(self, command, with_proxy=True, **kwargs):
-        """Run ssh command using Parallel SSH."""
+        """ Run ssh command using Parallel SSH."""
         result = {"0": [], "1": []}
         for site, hosts in self.groups.items():
-            proxy_host = '{}.iot-lab.info'.format(site) if with_proxy else None
-            hosts = hosts if with_proxy else ['{}.iot-lab.info'.format(site)]
+            proxy_host = site if with_proxy else None
+            hosts = hosts if with_proxy else [site]
             result_cmd = self.run_command(command,
                                           hosts=hosts,
                                           user=self.config_ssh['user'],
@@ -155,48 +143,39 @@ class OpenA8Ssh():
                                           proxy_host=proxy_host,
                                           **kwargs)
             result = _extend_result(result, result_cmd)
-
         return _cleanup_result(result)
 
     def scp(self, src, dst):
-        """Copy file to A8 node using Parallel SSH copy_file"""
+        """ Copy file to A8 node using Parallel SCP native client """
         result = {"0": [], "1": []}
-        sites = ['{}.iot-lab.info'.format(site) for site in self.groups]
+        sites = self.groups.keys()
         for site in sites:
             try:
-                ssh = SSHClient()
-                ssh.load_system_host_keys()
-                ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-                ssh.connect(site, username=self.config_ssh['user'], timeout=10)
-            except AuthenticationException:
-                raise OpenA8SshAuthenticationException(site)
-            except ConnectionErrorException:
-                result["1"].append(site)
-            else:
-                with SCPClient(ssh.get_transport()) as scp:
-                    scp.put(src, dst)
-                ssh.close()
+                client = SSHClient(site, user=self.config_ssh['user'],
+                                   timeout=10)
+                client.copy_file(src, dst)
                 result["0"].append(site)
+            except (SFTPError, UnknownHostError, ConnectionError,
+                    AuthenticationError):
+                result["1"].append(site)
         return _cleanup_result(result)
 
     def wait(self, max_wait):
-        """Wait for requested A8 nodes until they boot"""
+        """ Wait for requested A8 nodes until they boot"""
         result = {"0": [], "1": []}
         start_time = time.time()
         groups = self.groups.copy()
         while (start_time + max_wait > time.time() and
                not _check_all_nodes_processed(groups)):
             for site, hosts in groups.copy().items():
-                proxy_host = '{}.iot-lab.info'.format(site)
                 result_cmd = self.run_command("uptime",
                                               hosts=hosts,
                                               user=self.config_ssh['user'],
                                               verbose=self.verbose,
-                                              proxy_host=proxy_host)
+                                              proxy_host=site)
                 groups[site] = result_cmd["1"]
                 groups = _cleanup_result(groups)
                 result = _extend_result(result, result_cmd)
-
         return _cleanup_result(result)
 
     # pylint: disable=too-many-arguments
@@ -213,24 +192,21 @@ class OpenA8Ssh():
         else:
             client = ParallelSSHClient(hosts, user=user, timeout=timeout)
         output = client.run_command(command, stop_on_errors=False,
+                                    return_list=True,
                                     **kwargs)
-        client.join(output)
-        for host in hosts:
-            if host not in output:
-                # Pssh AuthenticationException duplicate output dict key
-                # {'saclay.iot-lab.info': {'exception': ...},
-                # {'saclay.iot-lab.info_qzhtyxlt': {'exception': ...}}
-                site = next(iter(sorted(output)))
-                raise OpenA8SshAuthenticationException(site)
-            result['0' if output[host]['exit_code'] == 0
-                   else '1'].append(host)
-        if verbose:
-            for host in hosts:
-                # Pssh >= 1.0.0: stdout is None instead of generator object
-                # when you have ConnectionErrorException
-                stdout = output[host].get('stdout')
-                if stdout:
-                    for _ in stdout:
-                        pass
-
+        client.join(output, consume_output=True)
+        # output = pssh.output.HostOutput objects list
+        for host in output:
+            if host.exit_code == 0:
+                if verbose and host.stdout:
+                    for line in host.stdout:
+                        print(line)
+                result['0'].append(host.host)
+            elif host.host is not None:
+                result['1'].append(host.host)
+        # find hosts that have raised Exception (Authentication, Connection)
+        # host.exception = pssh.exceptions.* & host.host = None
+        failed_hosts = list(set(hosts) - set(sum(result.values(), [])))
+        if failed_hosts:
+            result['1'].extend(failed_hosts)
         return result

--- a/iotlabsshcli/tests/open_a8_ssh_test.py
+++ b/iotlabsshcli/tests/open_a8_ssh_test.py
@@ -21,17 +21,29 @@
 
 """Tests for iotlabsshcli.open_a8 package."""
 
-from pytest import raises, mark
-from pssh.exceptions import AuthenticationException, ConnectionErrorException
+from pytest import mark
+from pssh.exceptions import SFTPError
 
 from iotlabsshcli.open_a8 import _nodes_grouped
-from iotlabsshcli.sshlib import OpenA8Ssh, OpenA8SshAuthenticationException
+from iotlabsshcli.sshlib import OpenA8Ssh
 from .compat import patch
 
-_SITES = ['saclay', 'grenoble']
-_NODES = ['a8-{}.{}.iot-lab.info'.format(n, s)
+_SITES = ['saclay.iot-lab.info', 'grenoble.iot-lab.info']
+_NODES = ['a8-{}.{}'.format(n, s)
           for n in range(1, 6) for s in _SITES]
 _ROOT_NODES = ['node-{}'.format(node) for node in _NODES]
+
+
+# pylint: disable=too-few-public-methods
+class HostOutput:
+    """  HostOutput test case class. ParallelSSH run_command
+         returns a list of pssh.output.HostOutput objects since
+         version 2.0.0
+    """
+    def __init__(self, host, stdout, exit_code):
+        self.host = host
+        self.stdout = stdout
+        self.exit_code = exit_code
 
 
 @mark.parametrize('run_on_frontend', [False, True])
@@ -52,26 +64,20 @@ def test_run(join, run_command, run_on_frontend):
 
     # Print output of run_command
     if run_on_frontend:
-        run_command.return_value = dict(
-            ("{}.iot-lab.info".format(site),
-             {'stdout': ['test'], 'exit_code': 0})
-            for site in _SITES)
+        output = [HostOutput(site, 'test', 0) for site in _SITES]
     else:
-        run_command.return_value = dict(
-            (node,
-             {'stdout': ['test'], 'exit_code': 0})
-            for node in _ROOT_NODES)
+        output = [HostOutput(node, 'test', 0) for node in _ROOT_NODES]
+    run_command.return_value = output
 
     node_ssh.run(test_command, with_proxy=not run_on_frontend)
     assert run_command.call_count == len(groups)
-    run_command.assert_called_with(test_command, stop_on_errors=False)
+    run_command.assert_called_with(test_command, stop_on_errors=False,
+                                   return_list=True)
 
 
-@patch('scp.SCPClient._open')
-@patch('scp.SCPClient.put')
-@patch('paramiko.SSHClient')
-@patch('paramiko.SSHClient.connect')
-def test_scp(connect, client, put, _open):
+@patch('pssh.clients.SSHClient._init')
+@patch('pssh.clients.SSHClient.copy_file')
+def test_scp(copy_file, init):
     # pylint: disable=unused-argument
     """Test wait for ssh nodes to be available."""
     config_ssh = {
@@ -86,20 +92,13 @@ def test_scp(connect, client, put, _open):
 
     node_ssh = OpenA8Ssh(config_ssh, groups, verbose=True)
     ret = node_ssh.scp(src, dst)
-
+    assert copy_file.call_count == len(_SITES)
     assert ret == {'0': ['saclay.iot-lab.info', 'grenoble.iot-lab.info']}
 
-    connect.side_effect = ConnectionErrorException()
+    copy_file.side_effect = SFTPError()
     ret = node_ssh.scp(src, dst)
 
     assert ret == {'1': ['saclay.iot-lab.info', 'grenoble.iot-lab.info']}
-
-    # Simulating an exception
-    # pylint: disable=redefined-variable-type
-    connect.side_effect = AuthenticationException()
-
-    with raises(OpenA8SshAuthenticationException):
-        node_ssh.scp(src, dst)
 
 
 @patch('pssh.clients.ParallelSSHClient.run_command')
@@ -118,49 +117,16 @@ def test_wait_all_boot(join, run_command):
     # normal boot
     node_ssh = OpenA8Ssh(config_ssh, groups, verbose=True)
 
-    # Print output of run_command
-    run_command.return_value = dict(
-        (node,
-         {'stdout': ['test'], 'exit_code': 0})
-        for node in _ROOT_NODES)
+    output = [HostOutput(node, 'test', 0) for node in _ROOT_NODES]
+    run_command.return_value = output
 
     node_ssh.wait(120)
     assert run_command.call_count == len(_SITES)
-    run_command.assert_called_with('uptime', stop_on_errors=False)
+    run_command.assert_called_with('uptime', stop_on_errors=False,
+                                   return_list=True)
     run_command.reset_mock()
 
     node_ssh.run(test_command)
     assert run_command.call_count == len(_SITES)
-    run_command.assert_called_with(test_command, stop_on_errors=False)
-
-
-@patch('pssh.clients.ParallelSSHClient.run_command')
-@patch('pssh.clients.ParallelSSHClient.join')
-def test_authentication_exception(join, run_command):
-    # pylint: disable=unused-argument
-    """Test SSH authentication exception with parallel-ssh
-    run_command and stop_on_errors=False option.
-    """
-    config_ssh = {
-        'user': 'username',
-        'exp_id': 123,
-    }
-
-    test_command = 'test'
-    groups = _nodes_grouped(_ROOT_NODES)
-
-    # normal boot
-    node_ssh = OpenA8Ssh(config_ssh, groups, verbose=True)
-
-    # Print output of run_command
-    run_command.return_value = dict(
-        ("{}.iot-lab.info".format(site),
-         {'stdout': None, 'exit_code': None})
-        for site in _SITES)
-
-    with raises(OpenA8SshAuthenticationException):
-        node_ssh.run(test_command)
-
-    # only one iteration as there is an exception
-    assert run_command.call_count == 1
-    run_command.assert_called_with(test_command, stop_on_errors=False)
+    run_command.assert_called_with(test_command, stop_on_errors=False,
+                                   return_list=True)

--- a/iotlabsshcli/tests/open_a8_test.py
+++ b/iotlabsshcli/tests/open_a8_test.py
@@ -27,9 +27,8 @@ from pytest import mark
 from iotlabsshcli.open_a8 import reset_m3, flash_m3, wait_for_boot, run_script
 from iotlabsshcli.open_a8 import run_cmd, copy_file
 from iotlabsshcli.open_a8 import (_RESET_M3_CMD, _UPDATE_M3_CMD,
-                                  _MKDIR_DST_CMD, _RUN_SCRIPT_CMD,
+                                  _RUN_SCRIPT_CMD,
                                   _QUIT_SCRIPT_CMD, _MAKE_EXECUTABLE_CMD)
-from iotlabsshcli.sshlib import OpenA8SshAuthenticationException
 from .compat import patch
 
 _NODES = ['a8-{}.{}.iot-lab.info'.format(n, s)
@@ -46,7 +45,7 @@ def test_open_a8_flash_m3(scp, run):
         'exp_id': 123,
     }
     firmware = '/tmp/firmware.elf'
-    remote_fw = os.path.join('~/A8/.iotlabsshcli', os.path.basename(firmware))
+    remote_fw = os.path.join('A8/.iotlabsshcli', os.path.basename(firmware))
     return_value = {'0': 'test'}
     run.return_value = return_value
 
@@ -54,15 +53,8 @@ def test_open_a8_flash_m3(scp, run):
 
     assert ret == {'flash-m3': return_value}
     scp.assert_called_once_with(firmware, remote_fw)
-    assert run.call_count == 2
-    run.mock_calls[0].assert_called_with(
-        _MKDIR_DST_CMD.format(os.path.dirname(remote_fw)))
-    run.mock_calls[1].assert_called_with(_UPDATE_M3_CMD.format(remote_fw))
-
-    # Raise an exception
-    run.side_effect = OpenA8SshAuthenticationException('test')
-    ret = flash_m3(config_ssh, _ROOT_NODES, firmware)
-    assert ret == {'flash-m3': {'1': _ROOT_NODES}}
+    assert run.call_count == 1
+    run.mock_calls[0].assert_called_with(_UPDATE_M3_CMD.format(remote_fw))
 
 
 @patch('iotlabsshcli.sshlib.OpenA8Ssh.run')
@@ -80,11 +72,6 @@ def test_open_a8_reset_m3(run):
 
     run.assert_called_once_with(_RESET_M3_CMD)
 
-    # Raise an exception
-    run.side_effect = OpenA8SshAuthenticationException('test')
-    ret = reset_m3(config_ssh, _ROOT_NODES)
-    assert ret == {'reset-m3': {'1': _ROOT_NODES}}
-
 
 @patch('iotlabsshcli.sshlib.OpenA8Ssh.wait')
 def test_open_a8_wait_for_boot(wait):
@@ -101,11 +88,6 @@ def test_open_a8_wait_for_boot(wait):
 
     wait.assert_called_once_with(120)
 
-    # Raise an exception
-    wait.side_effect = OpenA8SshAuthenticationException('test')
-    ret = wait_for_boot(config_ssh, _ROOT_NODES)
-    assert ret == {'wait-for-boot': {'1': _ROOT_NODES}}
-
 
 @mark.parametrize('run_on_frontend', [False, True])
 @patch('iotlabsshcli.sshlib.OpenA8Ssh.run')
@@ -118,7 +100,7 @@ def test_open_a8_run_script(scp, run, run_on_frontend):
     }
     screen = '{user}-{exp_id}'.format(**config_ssh)
     script = '/tmp/script.sh'
-    remote_script = os.path.join('~/A8/.iotlabsshcli',
+    remote_script = os.path.join('A8/.iotlabsshcli',
                                  os.path.basename(script))
     script_data = {'screen': screen,
                    'path': remote_script}
@@ -130,38 +112,29 @@ def test_open_a8_run_script(scp, run, run_on_frontend):
 
     assert ret == {'run-script': return_value}
     scp.assert_called_once_with(script, remote_script)
-    assert run.call_count == 4
+    assert run.call_count == 3
 
     run.mock_calls[0].assert_called_with(
-        _MKDIR_DST_CMD.format(os.path.dirname(remote_script)),
-        with_proxy=False)
-    run.mock_calls[1].assert_called_with(
         _MAKE_EXECUTABLE_CMD.format(os.path.dirname(remote_script)),
         with_proxy=False)
-    run.mock_calls[2].assert_called_with(
+    run.mock_calls[1].assert_called_with(
         _QUIT_SCRIPT_CMD.format(**script_data),
         with_proxy=not run_on_frontend)
-    run.mock_calls[3].assert_called_with(
+    run.mock_calls[2].assert_called_with(
         _RUN_SCRIPT_CMD.format(**script_data),
         use_pty=False,
         with_proxy=not run_on_frontend)
 
-    # Raise an exception
-    run.side_effect = OpenA8SshAuthenticationException('test')
-    ret = run_script(config_ssh, _ROOT_NODES, script)
-    assert ret == {'run-script': {'1': _ROOT_NODES}}
 
-
-@patch('iotlabsshcli.sshlib.OpenA8Ssh.run')
 @patch('iotlabsshcli.sshlib.OpenA8Ssh.scp')
-def test_open_a8_copy_file(scp, run):
+def test_open_a8_copy_file(scp):
     """Test copy file on the SSH frontend."""
     config_ssh = {
         'user': 'username',
         'exp_id': 123,
     }
     file_path = '/tmp/script.sh'
-    remote_file = os.path.join('~/A8/.iotlabsshcli',
+    remote_file = os.path.join('A8/.iotlabsshcli',
                                os.path.basename(file_path))
     return_value = {'0': 'test'}
     scp.return_value = return_value
@@ -170,13 +143,6 @@ def test_open_a8_copy_file(scp, run):
     assert ret == {'copy-file': return_value}
 
     scp.assert_called_once_with(file_path, remote_file)
-    run.assert_called_once_with(
-        _MKDIR_DST_CMD.format(os.path.dirname(remote_file)), with_proxy=False)
-
-    # Raise an exception
-    run.side_effect = OpenA8SshAuthenticationException('test')
-    ret = copy_file(config_ssh, _ROOT_NODES, file_path)
-    assert ret == {'copy-file': {'1': _ROOT_NODES}}
 
 
 @mark.parametrize('run_on_frontend', [False, True])
@@ -195,8 +161,3 @@ def test_open_a8_run_cmd(run, run_on_frontend):
                   run_on_frontend=run_on_frontend)
     run.assert_called_once_with(cmd, with_proxy=not run_on_frontend)
     assert ret == {'run-cmd': return_value}
-
-    # Raise an exception
-    run.side_effect = OpenA8SshAuthenticationException('test')
-    ret = run_cmd(config_ssh, _ROOT_NODES, cmd, False)
-    assert ret == {'run-cmd': {'1': _ROOT_NODES}}

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,8 @@ DEPRECATED_SCRIPTS = ['open-a8-cli']
 
 SCRIPTS += DEPRECATED_SCRIPTS
 
-INSTALL_REQUIRES = ['argparse', 'iotlabcli>=2.0', 'parallel-ssh>=1.6.0',
-                    'scp==0.11', 'gevent']
+INSTALL_REQUIRES = ['argparse', 'iotlabcli>=2.0', 'parallel-ssh>=2.2.0',
+                    'scp', 'gevent>=1.1', 'psutil==5.7.0']
 
 setup(
     name=PACKAGE,

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ DEPRECATED_SCRIPTS = ['open-a8-cli']
 
 SCRIPTS += DEPRECATED_SCRIPTS
 
-INSTALL_REQUIRES = ['argparse', 'iotlabcli>=2.0', 'parallel-ssh>=2.2.0',
+INSTALL_REQUIRES = ['argparse', 'iotlabcli>=2.0', 'parallel-ssh>=2.3.2',
                     'scp', 'gevent>=1.1', 'psutil==5.7.0']
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = copying,{py35,py36,py37}-{lint,tests},cli
+envlist = copying,{py27,py35,py36,py37}-{lint,tests},cli
 
 [tox:jenkins]
 skip_missing_interpreters = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = copying,{py27,py35,py36,py37}-{lint,tests},cli
+envlist = copying,{py35,py36,py37}-{lint,tests},cli
 
 [tox:jenkins]
 skip_missing_interpreters = True


### PR DESCRIPTION
* update parallel ssh version to 2.2.0
* use new output run command (HostOutput list)
* use parallel-ssh scp native client instead of Paramiko
* improve flash-m3 and run-script command: launches sub-commands (scp, run) only on nodes that are not in error