### PR TITLE
load IPv6 environment variables before run script.

### DIFF
--- a/iotlabsshcli/open_linux.py
+++ b/iotlabsshcli/open_linux.py
@@ -53,7 +53,7 @@ def _nodes_grouped(nodes):
 _FLASH_CMD = 'source /etc/profile && /usr/bin/iotlab_flash {}'
 _RESET_CMD = 'source /etc/profile && /usr/bin/iotlab_reset'
 _MAKE_EXECUTABLE_CMD = 'chmod +x {}'
-_RUN_SCRIPT_CMD = 'screen -S {screen} -dm bash -c \"{path}\"'
+_RUN_SCRIPT_CMD = 'source /etc/profile && screen -S {screen} -dm bash -c \"{path}\"'
 _QUIT_SCRIPT_CMD = 'screen -X -S {screen} quit'
 _REMOTE_SHARED_DIR = 'shared/.iotlabsshcli'
 


### PR DESCRIPTION
When using run cmd, the IPv6 environment variables are not loaded within the screen command (eg. INET6_PREFIX). Before calling screen, we need to load the IoT-LAB profile variables from our Open Linux.