### PR TITLE
Add support for flashing .bin firmwares

### DIFF
--- a/iotlabsshcli/open_linux.py
+++ b/iotlabsshcli/open_linux.py
@@ -50,7 +50,7 @@ def _nodes_grouped(nodes):
     return result
 
 
-_FLASH_CMD = 'source /etc/profile && /usr/bin/iotlab_flash {}'
+_FLASH_CMD = 'source /etc/profile && /usr/bin/iotlab_flash {fw} {bin}'
 _RESET_CMD = 'source /etc/profile && /usr/bin/iotlab_reset'
 _MAKE_EXECUTABLE_CMD = 'chmod +x {}'
 _RUN_SCRIPT_CMD = 'source /etc/profile && '
@@ -73,7 +73,8 @@ def flash(config_ssh, nodes, firmware, verbose=False):
     if '1' in result:
         failed_hosts = [ssh.groups.pop(res) for res in result['1']]
     # Run firmware update.
-    result = ssh.run(_FLASH_CMD.format(remote_fw))
+    bin_opt = "--bin" if remote_fw.endswith(".bin") else ""
+    result = ssh.run(_FLASH_CMD.format(fw=remote_fw, bin=bin_opt))
     for hosts in failed_hosts:
         result.setdefault('1', []).extend(hosts)
     return {"flash": result}

--- a/iotlabsshcli/tests/open_linux_test.py
+++ b/iotlabsshcli/tests/open_linux_test.py
@@ -60,7 +60,24 @@ def test_open_linux_flash(scp, run):
     assert ret == {'flash': return_value}
     scp.assert_called_once_with(firmware, remote_fw)
     assert run.call_count == 1
-    run.mock_calls[0].assert_called_with(_FLASH_CMD.format(remote_fw))
+    run.mock_calls[0].assert_called_with(
+        _FLASH_CMD.format(fw=remote_fw, bin="")
+    )
+
+    # Cover the case where a .bin firmware is used
+    scp.call_count = 0
+    run.call_count = 0
+    firmware = '/tmp/firmware.bin'
+    remote_fw = os.path.join('shared/.iotlabsshcli',
+                             os.path.basename(firmware))
+    ret = flash(config_ssh, _ROOT_NODES, firmware)
+
+    assert ret == {'flash': return_value}
+    scp.assert_called_once_with(firmware, remote_fw)
+    assert run.call_count == 1
+    run.mock_calls[0].assert_called_with(
+        _FLASH_CMD.format(fw=remote_fw, bin="--bin")
+    )
 
 
 @patch('iotlabsshcli.sshlib.OpenLinuxSsh.run')


### PR DESCRIPTION
I just realized that flashing a .bin firmware on the A8-M3 doesn't work. The flashing tool on the A8 requires the `--bin` option to be set in this case.

This PR modifies the iotlab-ssh flash command to correctly handle that case.