### PR TITLE
open_linux_ssh: remove return_list parameter from run_command call

### DIFF
--- a/iotlabsshcli/sshlib/open_linux_ssh.py
+++ b/iotlabsshcli/sshlib/open_linux_ssh.py
@@ -202,9 +202,7 @@ class OpenLinuxSsh():
         else:
             client = ParallelSSHClient(hosts, user=user, pkey=SSH_KEY,
                                        timeout=timeout)
-        # pylint: disable=unexpected-keyword-arg
         output = client.run_command(command, stop_on_errors=False,
-                                    return_list=True,
                                     **kwargs)
         client.join(output)
         # output = pssh.output.HostOutput objects list


### PR DESCRIPTION
The `ParallelSSHClient.run_command` function made the `return_list` no-op as of `parallel-ssh` v2.0.0 and the recent v2.6.0 "Removed deprecated since 2.0.0 functions and parameters." [[1]]. As such, with the current `parallel-ssh`, any command will fail with the following traceback:

    Traceback (most recent call last):
      File "/home/mlenders/Repositories/PIVOT/doc-eval/scripts/exp_ctrl/env/bin/iotlab-ssh", line 23, in <module>
        iotlabsshcli.parser.open_linux_parser.main()
      File "/home/mlenders/Repositories/PIVOT/doc-eval/scripts/exp_ctrl/env/lib/python3.9/site-packages/iotlabsshcli/parser/open_linux_parser.py", line 225, in main
        common.main_cli(open_linux_parse_and_run, parser, args)
      File "/home/mlenders/Repositories/PIVOT/doc-eval/scripts/exp_ctrl/env/lib/python3.9/site-packages/iotlabcli/parser/common.py", line 163, in main_cli
        result = function(parser_opts)
      File "/home/mlenders/Repositories/PIVOT/doc-eval/scripts/exp_ctrl/env/lib/python3.9/site-packages/iotlabsshcli/parser/open_linux_parser.py", line 184, in open_linux_parse_and_run
        res = iotlabsshcli.open_linux.flash(config_ssh, nodes,
      File "/home/mlenders/Repositories/PIVOT/doc-eval/scripts/exp_ctrl/env/lib/python3.9/site-packages/iotlabsshcli/open_linux.py", line 77, in flash
        result = ssh.run(_FLASH_CMD.format(fw=remote_fw, bin=bin_opt))
      File "/home/mlenders/Repositories/PIVOT/doc-eval/scripts/exp_ctrl/env/lib/python3.9/site-packages/iotlabsshcli/sshlib/open_linux_ssh.py", line 148, in run
        result_cmd = self.run_command(command,
      File "/home/mlenders/Repositories/PIVOT/doc-eval/scripts/exp_ctrl/env/lib/python3.9/site-packages/iotlabsshcli/sshlib/open_linux_ssh.py", line 205, in run_command
        output = client.run_command(command, stop_on_errors=False,
    TypeError: run_command() got an unexpected keyword argument 'return_list'

[1]: https://parallel-ssh.readthedocs.io/en/latest/Changelog.html